### PR TITLE
Run syntax tests on pushes and pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.github/ export-ignore
+.gitattributes export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Syntax Tests
+
+on:
+  push:
+    paths:
+      - '.github/workflows/ci.yml'
+      - '**.sublime-syntax'
+      - '**/syntax_test*'
+      - '**.tmPreferences'
+  pull_request:
+    paths:
+      - '.github/workflows/ci.yml'
+      - '**.sublime-syntax'
+      - '**/syntax_test*'
+      - '**.tmPreferences'
+
+jobs:
+  main:
+    name: Run Syntax Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: SublimeText/syntax-test-action@v2
+        with:
+          build: 'latest'
+          package_name: ModernFortran


### PR DESCRIPTION
This adds CI to automatically run the syntax tests on pushes and pull requests via a GitHub action.
For example this will display a nice checkmark or cross next to the commit hash on GitHub, as can be seen on the ci branch of my fork: https://github.com/jwortmann/modern-fortran-syntax/tree/ci

If you don't need this, feel free to close this PR.