### PR TITLE
Remove duplicate function names from symbol list

### DIFF
--- a/Symbol List.tmPreferences
+++ b/Symbol List.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>
+        source.fortran entity.name.function - meta.function.declaration
+    </string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedSymbolList</key>
+        <integer>0</integer>
+        <key>showInSymbolList</key>
+        <integer>0</integer>
+    </dict>
+</dict>
+</plist>

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -226,15 +226,18 @@ contexts:
     - match: '(?i)\b(module)\b\s+(?=function|subroutine|procedure)'
       scope: storage.modifier.function.prefix.fortran
 
-    - match: (?i)\b(function|subroutine)\b
-      scope: keyword.declaration.function.fortran
-
-    - match: (?i)\b(end)\b\s+(?=function|subroutine|procedure)
-      scope: keyword.declaration.function.fortran
-
-    - match: (?i)(?<=\bfunction|subroutine\b)\s+(\w+)
+    - match: (?i)\b(function|subroutine)(?:\s+(\w+))?\b
+      scope: meta.function.declaration.fortran
       captures:
-        1: entity.name.function.fortran
+        1: keyword.declaration.function.fortran
+        2: entity.name.function.fortran
+
+    - match: (?i)\b(end)\s+(?:(function|subroutine)(?:\s+(\w+))?|(procedure))\b
+      captures:
+        1: keyword.declaration.function.fortran
+        2: keyword.declaration.function.fortran
+        3: entity.name.function.fortran
+        4: keyword.declaration.function.fortran
 
     - match: '(?i)\b(call)\b'
       captures:
@@ -310,8 +313,8 @@ contexts:
     - include: separators
     - include: attribute
     - include: pointer-symbol
-    - match: (\w+)
-      scope: entity.name.function.fortran.fortran
+    - match: \w+
+      scope: entity.name.function.fortran
     - match: \n
       pop: true
     - match: \&

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -130,10 +130,12 @@
 !           ^^ keyword.operator.arithmetic.string-concatenation.fortran
 !
    function theFunction()
+!  ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.fortran
 !  ^^^^^^^^ keyword.declaration.function.fortran
 !           ^^^^^^^^^^^ entity.name.function.fortran
    pure function theFunction()
 !  ^^^^ storage.modifier.function.prefix.fortran
+!       ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.fortran
 !       ^^^^^^^^ keyword.declaration.function.fortran
 !                ^^^^^^^^^^^ entity.name.function.fortran
    recursive module function theFunction(a)
@@ -152,8 +154,9 @@
 !
    end function getStuff
 !  ^^^ keyword.declaration.function.fortran
+!     ^ - keyword
 !      ^^^^^^^^ keyword.declaration.function.fortran
-!               ^^^^^^^^ entity.name.function.fortran
+!               ^^^^^^^^ entity.name.function.fortran - meta.function.declaration
 !
    real(dp) function myFunction(a, b, c)
 !  ^^^^ storage.type.intrinsic.fortran
@@ -164,6 +167,7 @@
 !
    module subroutine doStuff(a, b, c)
 !  ^^^^^^ storage.modifier.function.prefix.fortran
+!         ^^^^^^^^^^^^^^^^^^ meta.function.declaration.fortran
 !         ^^^^^^^^^^ keyword.declaration.function.fortran
 !                    ^^^^^^^ entity.name.function.fortran
 !


### PR DESCRIPTION
Fixes #5

This PR adds the scope `meta.function.declaration` only to the first line of a function or subroutine declaration, and excludes function or subroutine names that don't have this scope from the symbol list.

*Note*: This will also remove the entries for e.g. `doStuff` and `myDoStuffRoutine` in the expression `procedure :: doStuff => myDoStuffRoutine` from the symbol list. I think this is an advantage, because the "Goto Symbol" feature is meant to easily jump to actual class or function definition blocks. But I'm not entirely sure because I haven't really used much of the oop features of the "modern" Fortran standards yet.