### PR TITLE
Improve detection and scopes for character strings

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -200,13 +200,17 @@ contexts:
       pop: true
 
   string-continuation:
-    - match: "&"
-      scope: punctuation.separator.continuation.fortran
+    - match: (\&)(?:\s*((!).*$))?
+      captures:
+        1: punctuation.separator.continuation.fortran
+        2: comment.line.fortran
+        3: punctuation.definition.comment.fortran
       push:
         # locate continuation on next line and pop
         - match: "&"
           scope: punctuation.separator.continuation.fortran
           pop: true
+        - include: comments
         - match: (?=\S)
           pop: true
 

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -177,31 +177,37 @@ contexts:
     - match: "//"
       scope: keyword.operator.arithmetic.string-concatenation.fortran
     - match: "'"
-      push: string.single
+      scope: punctuation.definition.string.begin.fortran
+      push: string-single
     - match: '"'
-      push: string.double
+      scope: punctuation.definition.string.begin.fortran
+      push: string-double
 
-  string.single:
+  string-single:
     - meta_scope: string.quoted.single.fortran
-    - include: string.continuation
+    - include: string-continuation
     - include: newline-pop
     - match: "'"
+      scope: punctuation.definition.string.end.fortran
       pop: true
 
-  string.double:
-    - meta_scope: string.quoted.single.fortran
-    - include: string.continuation
+  string-double:
+    - meta_scope: string.quoted.double.fortran
+    - include: string-continuation
     - include: newline-pop
     - match: '"'
+      scope: punctuation.definition.string.end.fortran
       pop: true
 
-  string.continuation:
+  string-continuation:
     - match: "&"
       scope: punctuation.separator.continuation.fortran
       push:
         # locate continuation on next line and pop
         - match: "&"
           scope: punctuation.separator.continuation.fortran
+          pop: true
+        - match: (?=\S)
           pop: true
 
   procedures:

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -200,11 +200,9 @@ contexts:
       pop: true
 
   string-continuation:
-    - match: (\&)(?:\s*((!).*$))?
+    - match: (\&)\s*$\n?
       captures:
         1: punctuation.separator.continuation.fortran
-        2: comment.line.fortran
-        3: punctuation.definition.comment.fortran
       push:
         # locate continuation on next line and pop
         - match: "&"

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -128,7 +128,15 @@
    & and more continuation!'
 !  ^ punctuation.separator.continuation.fortran
 !
-   'Line continuation character missing on the next line, & ! comment
+   'This is a simple string & !no comment here'
+!  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.fortran - punctuation.separator.continuation - comment
+!
+   'This is a simple string, &
+   ! this is a comment, followed by a blank line
+
+   & and this is continuation of the string'
+
+   'Line continuation character missing on the next line, &
       but highlighting of the rest of the file is still not messed up.'
     x = 1
 !   ^^^^^ - string

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -128,7 +128,7 @@
    & and more continuation!'
 !  ^ punctuation.separator.continuation.fortran
 !
-   'Line continuation character missing on the next line, &
+   'Line continuation character missing on the next line, & ! comment
       but highlighting of the rest of the file is still not messed up.'
     x = 1
 !   ^^^^^ - string

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -118,6 +118,8 @@
 !
    'This is a simple string'
 !  ^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.fortran
+!  ^ punctuation.definition.string.begin.fortran
+!                          ^ punctuation.definition.string.end.fortran
    &
 !  ^ punctuation.separator.continuation.fortran
 !
@@ -125,6 +127,11 @@
    & but "with" continuation, &
    & and more continuation!'
 !  ^ punctuation.separator.continuation.fortran
+!
+   'Line continuation character missing on the next line, &
+      but highlighting of the rest of the file is still not messed up.'
+    x = 1
+!   ^^^^^ - string
 !
    'string' // ' contatenation!'
 !           ^^ keyword.operator.arithmetic.string-concatenation.fortran
@@ -342,7 +349,9 @@
 !^^^^^ support.function.fpp
 
 #include "someFile.F08"
-!         ^^^^^^^^^^^^ string.quoted.single.fortran
+!        ^^^^^^^^^^^^^^ string.quoted.double.fortran
+!        ^ punctuation.definition.string.begin.fortran
+!                     ^ punctuation.definition.string.end.fortran
 
 !$omp parallel do private(I) schedule(dynamic)
 !^ support.function.omp
@@ -360,7 +369,9 @@
 
    type1 = "hello!" ! should understand that 'type1' is a variable
 !  ^^^^^ variable.other.fortran
-!           ^^^^^^ string.quoted.single.fortran
+!          ^^^^^^^^ string.quoted.double.fortran
+!          ^ punctuation.definition.string.begin.fortran
+!                 ^ punctuation.definition.string.end.fortran
 !                     ^^^^^^ comment.line.fortran
 !
    used_diag(j) = 5 ! should not recognize "use" as keyword
@@ -674,7 +685,7 @@ end program myProgram
 !        ^^^^ keyword.control.fortran
 !
    error stop "Something went wrong!"
-!             ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.fortran
+!             ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.fortran
 !  ^^^^^ keyword.control.fortran
 !        ^^^^ keyword.control.fortran
 !


### PR DESCRIPTION
This PR...

* Fixes the scope name for double quoted strings
* Adds punctuation scopes to the string quotes
* Adds a rule to bail out at the next non-whitespace character after a line continuation character, so that the rest of the file is not highlighted as a string. This improves highlighting during typing.
* Slightly adjusts context names for consistency