### PR TITLE
Allow to toggle comments with keybinding

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Comments</string>
+    <key>scope</key>
+    <string>source.fortran</string>
+    <key>settings</key>
+    <dict>
+        <key>shellVariables</key>
+        <array>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START</string>
+                <key>value</key>
+                <string>! </string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This definition is required for the toggle_comment functionality to work (default keybinding <kbd>ctrl</kbd>+<kbd>/</kbd>).