### PR TITLE
Automatic increase/decrease indentation in if and do

### DIFF
--- a/Indentation Rules.tmPreferences
+++ b/Indentation Rules.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+   <key>scope</key>
+   <string>source.fortran</string>
+   <key>settings</key>
+   <dict>
+      <key>decreaseIndentPattern</key>
+      <string>^\s*(elseif|else|end\s*do|end\s*if)\b.*$</string>
+      <key>increaseIndentPattern</key>
+      <string>^\s*(else|if|do|while)\b.*$</string>
+      <key>disableIndentNextLinePattern</key>
+      <string></string>
+   </dict>
+</dict>
+</plist>

--- a/Indentation Rules.tmPreferences
+++ b/Indentation Rules.tmPreferences
@@ -6,9 +6,9 @@
    <key>settings</key>
    <dict>
       <key>decreaseIndentPattern</key>
-      <string>^\s*(elseif|else|end\s*do|end\s*if)\b.*$</string>
+      <string>^\s*(elseif|elsei|else|end\s*do|end\s*if)\b.*$</string>
       <key>increaseIndentPattern</key>
-      <string>^\s*(else|if|do|while)\b.*$</string>
+      <string>^\s*(if|do|while)\b.*$</string>
       <key>disableIndentNextLinePattern</key>
       <string></string>
    </dict>


### PR DESCRIPTION
Suggested auto-indentation rules for if and do constructs.

I think this should be used with some care, but doing it for if and do could make the typing experience slightly better.