### PR TITLE
'else' no longer keyword.control in 'elsei'

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -124,12 +124,10 @@ contexts:
     - match: (?i)\b(then|exit|cycle)
       scope: keyword.control.fortran
       push: seek-conditional-label
-    - match: (?i)(?<=else)(if)
-      scope: keyword.control.fortran
     - match: (?i)(?<=else)(?!\s*if)
       scope: keyword.control.fortran
       push: seek-conditional-label
-    - match: (?i)(else)
+    - match: (?i)\b(else|elseif)\b
       scope: keyword.control.fortran
     - match: (?i)\b(if|do|while)\b
       scope: keyword.control.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -43,7 +43,11 @@
 !
    enddo
 !  ^^^^^ keyword.control.fortran
-
+!
+   elsei ! should not recognize 'else' in 'elsei'
+!  ^^^^ - keyword.control.fortran
+!
+!
    real(dp), intent(in) :: myReal ! a side-comment
 !  ^^^^ storage.type.intrinsic.fortran
 !       ^^ variable.other.fortran


### PR DESCRIPTION
Caused strange coloring when typing "elseif", since "else" would be recognized as keyword.control and "i" as variable.other. Now "else" and "elseif" are recognized, but not "elsei".