### PR TITLE
Add F95/f95 and F03/f03 to file_extensions

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -7,7 +7,7 @@
 # Sarai D. Folkestad and Eirik F. Kjønstad
 #
 name: Modern-Fortran
-file_extensions: [F90,F08,F18,f90,f08,f18]
+file_extensions: [F90,F95,F03,F08,F18,f90,f95,f03,f08,f18]
 scope: source.fortran
 
 variables:


### PR DESCRIPTION
The syntax is for F90 and newer and should also include intermediate file extensions.