### PR TITLE
Add highlighting for arguments in function and subroutine declarations

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -303,7 +303,6 @@ contexts:
             - meta_scope: meta.function.parameters.fortran
             - include: line-continuation
             - include: eol-pop
-            - include: class-accessing
             - match: \w+
               scope: variable.parameter.fortran
             - match: \,

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -55,6 +55,21 @@ contexts:
     - include: match-variable
     - include: omp
 
+  eol-pop:
+    - match: (?=\s*[!\n])
+      pop: true
+
+  line-continuation:
+    - match: (\&)\s*(?:((!).*$\n?)|$\n?)
+      captures:
+        1: punctuation.separator.continuation.fortran
+        2: comment.line.fortran
+        3: punctuation.definition.comment.fortran
+      push:
+        - include: comments
+        - match: (?=\S)
+          pop: true
+
   comments:
     - match: '!(?![$])'
       scope: punctuation.definition.comment.fortran
@@ -115,7 +130,7 @@ contexts:
   control:
     - include: comments
     - match: (?i)^{{s}}*\b(end){{s}}*(if|do|select)
-      captures: 
+      captures:
         1: keyword.control.fortran
         2: keyword.control.fortran
       push: seek-conditional-label
@@ -220,10 +235,6 @@ contexts:
       captures:
         1: variable.function.subroutine.intrinsic.fortran
 
-    - match: (?i)\s*(result)\s*\(
-      captures:
-        1: keyword.control.function-result.fortran
-
     - match: (?i)\b(impure|pure|elemental|non\_recursive|recursive)\b
       scope: storage.modifier.function.prefix.fortran
 
@@ -233,11 +244,73 @@ contexts:
     - match: '(?i)\b(module)\b\s+(?=function|subroutine|procedure)'
       scope: storage.modifier.function.prefix.fortran
 
-    - match: (?i)\b(function|subroutine)(?:\s+(\w+))?\b
-      scope: meta.function.declaration.fortran
-      captures:
-        1: keyword.declaration.function.fortran
-        2: entity.name.function.fortran
+    - match: (?i)\bfunction\b
+      scope: meta.function.declaration.fortran keyword.declaration.function.fortran
+      push:
+        - meta_content_scope: meta.function.declaration.fortran
+        - include: line-continuation
+        - include: eol-pop
+        - match: \w+
+          scope: entity.name.function.fortran
+        - match: \(
+          scope: punctuation.section.parens.begin.fortran
+          push:
+            - clear_scopes: 1
+            - meta_scope: meta.function.parameters.fortran
+            - include: line-continuation
+            - include: eol-pop
+            - match: \w+
+              scope: variable.parameter.input.fortran
+            - match: \,
+              scope: punctuation.separator.comma.fortran
+            - match: \)
+              scope: punctuation.section.parens.end.fortran
+              set:
+                - include: line-continuation
+                - include: eol-pop
+                - match: (?i)\bresult\b
+                  scope: keyword.control.function-result.fortran
+                - match: (?=\()
+                  set:
+                    - clear_scopes: 1
+                    - match: \(
+                      scope: punctuation.section.parens.begin.fortran
+                      set:
+                        - clear_scopes: 1
+                        - meta_scope: meta.function.parameters.fortran
+                        - include: line-continuation
+                        - include: eol-pop
+                        - match: \w+
+                          scope: variable.parameter.output.fortran
+                        - match: \,
+                          scope: punctuation.separator.comma.fortran
+                        - match: \)
+                          scope: punctuation.section.parens.end.fortran
+                          pop: true
+
+    - match: (?i)\bsubroutine\b
+      scope: keyword.declaration.function.fortran
+      push:
+        - meta_scope: meta.function.declaration.fortran
+        - include: line-continuation
+        - include: eol-pop
+        - match: \w+
+          scope: entity.name.function.fortran
+        - match: \(
+          scope: punctuation.section.parens.begin.fortran
+          push:
+            - clear_scopes: 1
+            - meta_scope: meta.function.parameters.fortran
+            - include: line-continuation
+            - include: eol-pop
+            - include: class-accessing
+            - match: \w+
+              scope: variable.parameter.fortran
+            - match: \,
+              scope: punctuation.separator.comma.fortran
+            - match: \)
+              scope: punctuation.section.parens.end.fortran
+              pop: true
 
     - match: (?i)\b(end)\s+(?:(function|subroutine)(?:\s+(\w+))?|(procedure))\b
       captures:
@@ -362,10 +435,10 @@ contexts:
     - match: (?i)\b(abstract)\b
       scope: storage.modifier.fortran
     - match: (?<=::)\s*(\w+)
-      captures: 
+      captures:
         1: entity.name.class.fortran
     - match: (?i)(?<=type)\s+(\w+) # simple type definition (type myType)
-      captures: 
+      captures:
         1: entity.name.class.fortran
 
   numbers:
@@ -385,7 +458,6 @@ contexts:
       scope: constant.language.fortran
 
   class-accessing:
-    - include: comments
     - match: '(\w+)\s*(?=\%|\[.*\]\(.*\)\%|\(.*\)\%|\[.*\]\%)'
       scope: storage.type.class.fortran
 
@@ -468,7 +540,7 @@ contexts:
 
   program:
     - match: (?i)^{{s}}*\b(program)\b{{s}}+(\w+)\b{{s}}*$
-      scope: meta.program.declaration.fortran 
+      scope: meta.program.declaration.fortran
       captures:
         1: keyword.declaration.program.fortran
         2: entity.name.program.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -151,26 +151,56 @@
 !
    function theFunction()
 !  ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.fortran
+!                      ^^ meta.function.parameters.fortran
 !  ^^^^^^^^ keyword.declaration.function.fortran
 !           ^^^^^^^^^^^ entity.name.function.fortran
    pure function theFunction()
 !  ^^^^ storage.modifier.function.prefix.fortran
 !       ^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.fortran
+!                           ^^ meta.function.parameters.fortran
 !       ^^^^^^^^ keyword.declaration.function.fortran
 !                ^^^^^^^^^^^ entity.name.function.fortran
    recursive module function theFunction(a)
 !  ^^^^^^^^^ storage.modifier.function.prefix.fortran
 !            ^^^^^^ storage.modifier.function.prefix.fortran
-!                                        ^ variable.other.fortran
+!                                       ^^^ meta.function.parameters.fortran
+!                                       ^ punctuation.section.parens.begin.fortran
+!                                        ^ variable.parameter.input.fortran
+!                                         ^ punctuation.section.parens.end.fortran
    function theFunction(a, bee, cesium)
-!                       ^ variable.other.fortran
-!                          ^^^ variable.other.fortran
-!                               ^^^^^^ variable.other.fortran
+!                      ^^^^^^^^^^^^^^^^ meta.function.parameters.fortran
+!                      ^ punctuation.section.parens.begin.fortran
+!                       ^ variable.parameter.input.fortran
 !                        ^ punctuation.separator.comma.fortran
+!                          ^^^ variable.parameter.input.fortran
+!                             ^ punctuation.separator.comma.fortran
+!                               ^^^^^^ variable.parameter.input.fortran
+!                                     ^ punctuation.section.parens.end.fortran
+   function theFunction(a, & ! comment
+!                      ^^^^^^^^^^^^^^^^ meta.function.parameters.fortran
+!                          ^ punctuation.separator.continuation.fortran
+!                            ^^^^^^^^^^ comment.line.fortran
+
+      b, c)
+!^^^^^^^^^^ meta.function.parameters.fortran
+!     ^ variable.parameter.input.fortran
+!
+   function result(a)
+!           ^^^^^^ entity.name.function.fortran - keyword
 !
    pure function getStuff(a) result(theStuff)
+!       ^^^^^^^^^^^^^^^^^ meta.function.declaration.fortran - meta.function meta.function
+!                        ^^^ meta.function.parameters.fortran - meta.function meta.function
+!                           ^^^^^^^ meta.function.declaration.fortran - meta.function meta.function
+!                                  ^^^^^^^^^^ meta.function.parameters.fortran - meta.function meta.function
+!                                            ^ - meta.function.parameters
+!                        ^ punctuation.section.parens.begin.fortran
+!                         ^ variable.parameter.input.fortran
+!                          ^ punctuation.section.parens.end.fortran
 !                            ^^^^^^ keyword.control.function-result.fortran
-!                                   ^^^^^^^^ variable.other.fortran
+!                                  ^ punctuation.section.parens.begin.fortran
+!                                   ^^^^^^^^ variable.parameter.output.fortran
+!                                           ^ punctuation.section.parens.end.fortran
 !
    end function getStuff
 !  ^^^ keyword.declaration.function.fortran
@@ -199,14 +229,14 @@
    module subroutine doStuff(ace, bees, cees, & ! a comment
 !                                             ^ punctuation.separator.continuation.fortran
                              dees, ees, fsss)
-!                            ^^^^ variable.other.fortran
+!                            ^^^^ variable.parameter.fortran
 !
    module myModule
 !  ^^^^^^ keyword.declaration.interface.module.fortran
 !         ^^^^^^^^ entity.name.interface.module.fortran
 !  ^^^^^^^^^^^^^^^ meta.module.declaration.fortran
 !
-   end module myModule 
+   end module myModule
 !  ^^^ keyword.declaration.interface.module.fortran
 !      ^^^^^^ keyword.declaration.interface.module.fortran
 !             ^^^^^^^^ entity.name.interface.module.fortran - meta.module.declaration.fortran
@@ -404,21 +434,21 @@
    real(dp) function myFunction(a, b, c) result(someResult)
 !  ^^^^ storage.type.intrinsic.fortran
 !       ^^ variable.other.fortran
-!                                               ^^^^^^^^^^ variable.other.fortran
+!                                               ^^^^^^^^^^ variable.parameter.output.fortran
 !           ^^^^^^^^ keyword.declaration.function.fortran
 !                    ^^^^^^^^^^ entity.name.function.fortran
 !
 program myProgram
 !<-^^^^ keyword.declaration.program.fortran
 !       ^^^^^^^^^ entity.name.program.fortran
-!<-^^^^^^^^^^^^^^ meta.program.declaration.fortran 
+!<-^^^^^^^^^^^^^^ meta.program.declaration.fortran
 !
 !  Program contents
 !
 end program myProgram
 !<- keyword.declaration.program.fortran
 !   ^^^^^^^ keyword.declaration.program.fortran
-!           ^^^^^^^^^ entity.name.program.fortran - meta.program.declaration.fortran 
+!           ^^^^^^^^^ entity.name.program.fortran - meta.program.declaration.fortran
 !
    DO I = 1, 10
 !  ^^ keyword.control.fortran
@@ -521,11 +551,11 @@ end program myProgram
 !  ^^^^^^ storage.modifier.function.prefix.fortran
 !         ^^^^^^^^^^ keyword.declaration.function.fortran
 !                    ^^^^^^^^^^^^^ entity.name.function.fortran
-!                                  ^ variable.other.fortran
+!                                  ^ variable.parameter.fortran
 !                                   ^ punctuation.separator.comma.fortran
 !                                      ^ punctuation.separator.comma.fortran
-!                                     ^ variable.other.fortran
-!                                            ^^^ variable.other.fortran
+!                                     ^ variable.parameter.fortran
+!                                            ^^^ variable.parameter.fortran
 !                                        ^^^ storage.type.class.fortran
 
    read(unit=fileUnit, *) myVariable

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -547,7 +547,7 @@ end program myProgram
 !                ^ punctuation.separator.comma.fortran
 !                               ^^ punctuation.separator.double-colon.fortran
 !
-   MODULE SUBROUTINE MY_SUBROUTINE(A, B, Cee%Dee)
+   MODULE SUBROUTINE MY_SUBROUTINE(A, B, C)
 !  ^^^^^^ storage.modifier.function.prefix.fortran
 !         ^^^^^^^^^^ keyword.declaration.function.fortran
 !                    ^^^^^^^^^^^^^ entity.name.function.fortran
@@ -555,8 +555,8 @@ end program myProgram
 !                                   ^ punctuation.separator.comma.fortran
 !                                      ^ punctuation.separator.comma.fortran
 !                                     ^ variable.parameter.fortran
-!                                            ^^^ variable.parameter.fortran
-!                                        ^^^ storage.type.class.fortran
+!                                        ^ variable.parameter.fortran
+
 
    read(unit=fileUnit, *) myVariable
 !  ^^^^ variable.function.subroutine.intrinsic.io.fortran


### PR DESCRIPTION
... and proper `punctuation` scopes for the parentheses.

Note:
* There was a `- include: comments` in the "class-accessing" context, but I believe it had no effect because this context was only included in the "main" context, which also includes `comments` separately. So I removed it.
* I'm not really familiar with the syntax `Cee%Dee` in `MODULE SUBROUTINE MY_SUBROUTINE(A, B, Cee%Dee)`. The `Cee` part was scoped `storage.type.class` before, so I kept this scope here via the "class-accessing" context. Not sure whether the whole `Cee%Dee` expression should better be `variable.parameter` here?
* I saw that you already had a "continuation-context" context, but as defined it wasn't sufficient to use here, so I defined another "line-continuation". They could probably get merged together later.