### PR TITLE
Whitespace incorrectly scoped in variable declaration and interface names

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -472,7 +472,8 @@ contexts:
     - match: (?i)\b(interface)\b
       scope: keyword.declaration.interface.interface.fortran
     - match: '(?i)(?<=interface)\s+(\w*)'
-      scope: entity.name.interface.interface.fortran
+      captures: 
+        1: entity.name.interface.interface.fortran
     - match: (?i)\b(include)\b
       scope: keyword.control.import.fortran
     - match: (?i)\b(end)\b\s+(?=interface)

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -86,7 +86,8 @@ contexts:
     - match: '(?i)\b(in|out|inout)\b'
       scope: keyword.other.intent.fortran
     - match: '(?<=::)\s*(\w+)'
-      scope: variable.other.fortran
+      captures: 
+        1: variable.other.fortran
     - match: '(?i){{firstOnLine}}(type|class){{parenthesisStart}}\s*(\w*){{parenthesisEnd}}'
       captures:
         1: storage.type.class.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -281,6 +281,8 @@
    interface myInterface
 !  ^^^^^^^^^ keyword.declaration.interface.interface.fortran
 !            ^^^^^^^^^^^ entity.name.interface.interface.fortran
+!           ^ - entity.name.interface.interface.fortran
+!                       ^^^ - entity.name.interface.interface.fortran
 !
       include "path/to/file.F90"
 !     ^^^^^^^ keyword.control.import.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -27,6 +27,8 @@
 !    ^ keyword.operator.assignment.fortran
 !
    integer(kind=8), dimension(:,:), allocatable :: myInt
+!                                                  ^^^^^ variable.other.fortran
+!                                                 ^ - variable.other.fortran
 !  ^^^^^^^ storage.type.intrinsic.fortran
 !                   ^^^^^^^^^ storage.modifier.fortran
 !                                   ^^^^^^^^^^^ storage.modifier.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -584,7 +584,7 @@ end program myProgram
    end do extraordinaryLoop
 !         ^^^^^^^^^^^^^^^^^ entity.name.label.conditional.fortran
 !
-   readingTime : if (.not. person%hasBooks()) then
+   readingTime : if (person%hasBooks()) then
 !              ^ punctuation.separator.single-colon.fortran
 !  ^^^^^^^^^^^ entity.name.label.conditional.fortran
 !


### PR DESCRIPTION
e.g. `integer :: myInt` recognized the whitespace before `myInt` as variable.other. This is now fixed.