### PR TITLE
Preprocessor scope adjusted to keyword.control.directive

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -535,9 +535,9 @@ contexts:
 
   preprocessing:
     - match: '{{firstOnLine}}(\#)'
-      scope: support.function.fpp
+      scope: keyword.control.directive.fortran
     - match: '(?i)(?<=\#)({{fppCommands}})'
-      scope: support.function.fpp
+      scope: keyword.control.directive.fortran
 
   program:
     - match: (?i)^{{s}}*\b(program)\b{{s}}+(\w+)\b{{s}}*$

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -398,13 +398,15 @@
 !                         ^^^ variable.other.fortran
 !
 #ifdef myVar
+!<-^^^ keyword.control.directive.fortran
 !      ^^^^^ variable.other.fortran
    integer, parameter :: p = 1
 #else
+!<-^^ keyword.control.directive.fortran
    integer, parameter :: p = 2
 #endif
-!<- support.function.fpp
-!^^^^^ support.function.fpp
+!<- keyword.control.directive.fortran
+!^^^^^ keyword.control.directive.fortran
 
 #include "someFile.F08"
 !        ^^^^^^^^^^^^^^ string.quoted.double.fortran


### PR DESCRIPTION
Changed to `keyword.control.directive.fortran`, as suggested in #4 