### PR TITLE
Use keyword.control.directive on omp-directives and clauses 

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -481,10 +481,10 @@ contexts:
 
   omp:
     - match: '{{firstOnLine}}(?i)(\!\$omp)'
-      scope: support.function.omp
+      scope: keyword.control.directive.fortran
       push: omp-line
     - match: '{{firstOnLine}}(\!\$)'
-      scope: support.function.omp
+      scope: keyword.control.directive.fortran
       push: omp-line
 
   omp-line:
@@ -495,7 +495,7 @@ contexts:
     - include: separators
     - include: operators
     - match: (?i)(schedule)
-      scope: support.function.omp
+      scope: keyword.control.directive.fortran
       push: omp-schedule
     - include: match-variable
     - match: '\n'
@@ -503,7 +503,7 @@ contexts:
 
   omp-directives:
     - match: (?i)({{ompDirectives}})
-      scope: support.function.omp
+      scope: keyword.control.directive.fortran
 
   omp-intrinsic:
     - match: (?i)({{ompIntrinsics}})
@@ -512,7 +512,7 @@ contexts:
   omp-clauses:
     - include: omp-continuation
     - match: (?i)({{ompClauses}})
-      scope: support.constant.omp
+      scope: keyword.control.directive.fortran
 
   omp-schedule:
     - include: omp-continuation
@@ -526,7 +526,7 @@ contexts:
     - match: "&"
       push:
         - match: '{{firstOnLine}}(?i)(\!\$omp)'
-          scope: support.function.omp
+          scope: keyword.control.directive.fortran
           pop: true
 
   match-variable:

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -414,18 +414,28 @@
 !                     ^ punctuation.definition.string.end.fortran
 
 !$omp parallel do private(I) schedule(dynamic)
-!^ support.function.omp
-!                            ^^^^^^^^ support.function.omp
+!<^^^ keyword.control.directive.fortran
+!                            ^^^^^^^^ keyword.control.directive.fortran
+!     ^^^^^^^^ keyword.control.directive.fortran
+!              ^^ keyword.control.directive.fortran
+!                 ^^^^^^^ keyword.control.directive.fortran
+!                            ^^^^^^^^ keyword.control.directive.fortran
 !                         ^ variable.other.fortran
 !                                     ^^^^^^^ support.constant.omp
-!                 ^^^^^^^ support.constant.omp
-! ^^^ support.function.omp
    do I = 1, 10
+!
+!$    thread = omp_get_num_threads()
+!^ keyword.control.directive.fortran
+!              ^^^^^^^^^^^^^^^^^^^ support.function.omp
 !
       f(I) = someThing(I)
 !
    enddo
 !$omp end parallel do
+!<^^^ keyword.control.directive.fortran
+!                  ^^ keyword.control.directive.fortran
+!     ^^^ keyword.control.directive.fortran
+!         ^^^^^^^^ keyword.control.directive.fortran
 
    type1 = "hello!" ! should understand that 'type1' is a variable
 !  ^^^^^ variable.other.fortran


### PR DESCRIPTION
Some suggested changes to omp scopes.

Adjusts scope of directives (`omp`, `parallel`, `do`,...) to `keyword.control.directive.fortran` and similarly for omp clauses (`default`, `shared`, `private`,...) - as suggested in #4. I kept `support.constant` and `support.function` for possible schedule values (`guided`, `static`, ...) and omp intrinsic functions (`omp_get_num_threads` and so on). 
