### PR TITLE
Improve highlighting for module and program keywords

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -22,7 +22,6 @@ variables:
   parenthesisStart: '\(\s*'
   parenthesisEnd: '\s*\)'
   variableMatch: '[A-Za-z_][A-Za-z_0-9]*'
-  s: '[^\S\r\n]' # blank but not newline
   ompDirectives: '(end|parallel|do|simd|single|target|update|workshare|declare|sections|distribute|teams|task|taskyield|master|critical|barrier|taskwait|taskgroup|atomic|flush|ordered|cancel|cancellation point|reduction)'
   ompIntrinsics: (omp_set_num_threads|omp_get_num_threads|omp_get_max_threads|omp_get_thread_num|omp_get_num_procs|omp_in_parallel|omp_set_dynamic|omp_get_dynamic|omp_get_cancellation|omp_set_nested|omp_get_nested|omp_set_schedule|omp_get_schedule|omp_get_thread_limit|omp_set_max_active_levels|omp_get_max_active_levels|omp_get_level|omp_get_ancestor_thread_num|omp_get_team_size|omp_get_active_level|omp_in_final|omp_get_proc_bind|omp_set_default_device|omp_get_default_device|omp_get_num_devices|omp_get_num_teams|omp_get_team_num|omp_is_initial_device|omp_init_lock|omp_init_nest_lock|omp_destroy_lock|omp_destroy_nest_lock|omp_set_lock|omp_set_nest_lock|omp_unset_lock|omp_unset_nest_lock|omp_test_lock|omp_test_nest_lock|omp_get_wtime|omp_get_wtick)
   ompClauses: (default|shared|private|firstprivate|lastprivate|linear|reduction|copyin|copyprivate|map|tofrom|safelen|collapse|simdlen|aligned|uniform|Inbrach|notinbranch)
@@ -86,7 +85,7 @@ contexts:
     - match: '(?i)\b(in|out|inout)\b'
       scope: keyword.other.intent.fortran
     - match: '(?<=::)\s*(\w+)'
-      captures: 
+      captures:
         1: variable.other.fortran
     - match: '(?i){{firstOnLine}}(type|class){{parenthesisStart}}\s*(\w*){{parenthesisEnd}}'
       captures:
@@ -130,7 +129,7 @@ contexts:
 
   control:
     - include: comments
-    - match: (?i)^{{s}}*\b(end){{s}}*(if|do|select)
+    - match: (?i)^\s*\b(end)\s*(if|do|select)
       captures:
         1: keyword.control.fortran
         2: keyword.control.fortran
@@ -242,11 +241,14 @@ contexts:
     - match: (?i)(implicit none)
       scope: keyword.control.fortran
 
-    - match: '(?i)\b(module)\b\s+(?=function|subroutine|procedure)'
+    - match: '(?i)\b(module)(?=\s+procedure\b)'
       scope: storage.modifier.function.prefix.fortran
 
-    - match: (?i)\bfunction\b
-      scope: meta.function.declaration.fortran keyword.declaration.function.fortran
+    - match: (?i)(?:\b(module)\s+)?\b(function)\b
+      scope: meta.function.declaration.fortran
+      captures:
+         1: storage.modifier.function.prefix.fortran
+         2: keyword.declaration.function.fortran
       push:
         - meta_content_scope: meta.function.declaration.fortran
         - include: line-continuation
@@ -289,8 +291,10 @@ contexts:
                           scope: punctuation.section.parens.end.fortran
                           pop: true
 
-    - match: (?i)\bsubroutine\b
-      scope: keyword.declaration.function.fortran
+    - match: (?i)(?:\b(module)\s+)?\b(subroutine)\b
+      captures:
+        1: storage.modifier.function.prefix.fortran
+        2: keyword.declaration.function.fortran
       push:
         - meta_scope: meta.function.declaration.fortran
         - include: line-continuation
@@ -340,23 +344,25 @@ contexts:
       scope: keyword.control.fortran
 
   modules:
-    - match: (?i)^{{s}}*\b(module)\b{{s}}+(\w+)\b{{s}}*$
+    - match: (?i)\b(module)(?:\s+(\w+))?\b
       scope: meta.module.declaration.fortran
       captures:
         1: keyword.declaration.interface.module.fortran
         2: entity.name.interface.module.fortran
-    - match: (?i)^{{s}}*\b(end)\b{{s}}+\b(module)\b{{s}}+(\w*)
+    - match: (?i){{firstOnLine}}(end)\s+(module)(?:\s+(\w+))?\b
       captures:
         1: keyword.declaration.interface.module.fortran
         2: keyword.declaration.interface.module.fortran
         3: entity.name.interface.module.fortran
-    - match: (?i)^{{s}}*\b(submodule)\b{{s}}+\((\w+)\){{s}}+(\w+){{s}}*$
+    - match: (?i){{firstOnLine}}(submodule)(?:\s+(\()\s*(\w+)\s*(\))(?:\s+(\w+))?)?
       scope: meta.submodule.declaration.fortran
       captures:
         1: keyword.declaration.interface.submodule.fortran
-        2: entity.name.interface.inherited-module.fortran
-        3: entity.name.interface.submodule.fortran
-    - match: (?i)^{{s}}*\b(end)\b{{s}}+\b(submodule)\b{{s}}+(\w*)
+        2: punctuation.section.parens.begin.fortran
+        3: entity.name.interface.inherited-module.fortran
+        4: punctuation.section.parens.end.fortran
+        5: entity.name.interface.submodule.fortran
+    - match: (?i){{firstOnLine}}(end)\s+(submodule)(?:\s+(\w+))?\b
       captures:
         1: keyword.declaration.interface.submodule.fortran
         2: keyword.declaration.interface.submodule.fortran
@@ -472,7 +478,7 @@ contexts:
     - match: (?i)\b(interface)\b
       scope: keyword.declaration.interface.interface.fortran
     - match: '(?i)(?<=interface)\s+(\w*)'
-      captures: 
+      captures:
         1: entity.name.interface.interface.fortran
     - match: (?i)\b(include)\b
       scope: keyword.control.import.fortran
@@ -540,12 +546,12 @@ contexts:
       scope: keyword.control.directive.fortran
 
   program:
-    - match: (?i)^{{s}}*\b(program)\b{{s}}+(\w+)\b{{s}}*$
+    - match: (?i){{firstOnLine}}(program)(?:\s+(\w+))?\b
       scope: meta.program.declaration.fortran
       captures:
         1: keyword.declaration.program.fortran
         2: entity.name.program.fortran
-    - match: (?i)^{{s}}*(end)\b{{s}}+\b(program)\b{{s}}+(\w*)\b{{s}}*$
+    - match: (?i){{firstOnLine}}(end)\s+(program)(?:\s+(\w+))?\b
       captures:
         1: keyword.declaration.program.fortran
         2: keyword.declaration.program.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -238,10 +238,19 @@
 !         ^^^^^^^^ entity.name.interface.module.fortran
 !  ^^^^^^^^^^^^^^^ meta.module.declaration.fortran
 !
+   module myModule ! comment
+!  ^^^^^^ keyword.declaration.interface.module.fortran
+!         ^^^^^^^^ entity.name.interface.module.fortran
+!  ^^^^^^^^^^^^^^^ meta.module.declaration.fortran
+!
    end module myModule
 !  ^^^ keyword.declaration.interface.module.fortran
 !      ^^^^^^ keyword.declaration.interface.module.fortran
 !             ^^^^^^^^ entity.name.interface.module.fortran - meta.module.declaration.fortran
+!
+   end module
+!  ^^^ keyword.declaration.interface.module.fortran
+!      ^^^^^^ keyword.declaration.interface.module.fortran
 !
    submodule (moduleName) submoduleName
 !  ^^^^^^^^^ keyword.declaration.interface.submodule.fortran
@@ -255,6 +264,11 @@
 !
    end submodule ! just empty end-name also allowed
 !      ^^^^^^^^^ keyword.declaration.interface.submodule.fortran
+!
+   end submodule
+!  ^^^ keyword.declaration.interface.submodule.fortran
+!      ^^^^^^^^^keyword.declaration.interface.submodule.fortran
+!
    8
 !  ^ constant.numeric.fortran
 !


### PR DESCRIPTION
* Fixes some problems in case of comments after module declarations or
  linebreak immedeately after `end module`
* Remove the {{s}} variable for "blank but not newline", because ST
  matches only single lines anyway
* Tweak corresponding regex patterns a bit to improve highlighting of
  incomplete statements (while typing)