### PR TITLE
End keyword recognized as keyword.control

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -52,7 +52,8 @@ contexts:
     - include: stop
     - include: function-call
     - include: pointer-symbol
-    - include: match-variable
+    - include: match-end 
+    - include: match-variable 
     - include: omp
 
   eol-pop:
@@ -327,7 +328,7 @@ contexts:
     - match: '(?i)\b({{intrinsicIO}})\b'
       captures:
         1: variable.function.subroutine.intrinsic.io.fortran
-    - match: '(?i)\b({{intrinsicIOArguments}})\b'
+    - match: '(?i)\b({{intrinsicIOArguments}})\b\s*(?=\=)'
       captures:
         1: variable.language.io.fortran
 
@@ -528,6 +529,10 @@ contexts:
         - match: '{{firstOnLine}}(?i)(\!\$omp)'
           scope: keyword.control.directive.fortran
           pop: true
+
+  match-end:
+    - match: \bend\b
+      scope: keyword.control.fortran
 
   match-variable:
     - match: ({{variableMatch}})

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -16,6 +16,13 @@
    endif
 !  ^^^^ keyword.control.fortran
 !
+   end 
+!  ^^^ keyword.control.fortran 
+!
+   read(unit=myUnit, end=200) byte ! Read until end of file, then go to 200
+!       ^^^^ variable.language.io.fortran
+!                    ^^^ variable.language.io.fortran
+!
    a == b .and. c
 !    ^^ keyword.operator.comparison.fortran
 !         ^^^^^ keyword.operator.word.fortran


### PR DESCRIPTION
Makes two changes to resolve #33 
- "end" is recognized as keyword.control.fortran
- IO intrinsic arguments are now only recognized if followed by "=" as in `read(unit=myUnit)`. This can be further improved by only recognizing such in variable list of an IO subroutine (e.g. read), but provides a simple fix for now.