### PR TITLE
Fix scopes for type instance (variable) declaration

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -51,8 +51,8 @@ contexts:
     - include: stop
     - include: function-call
     - include: pointer-symbol
-    - include: match-end 
-    - include: match-variable 
+    - include: match-end
+    - include: match-variable
     - include: omp
 
   eol-pop:
@@ -85,13 +85,17 @@ contexts:
       scope: storage.type.intrinsic.fortran
     - match: '(?i)\b(in|out|inout)\b'
       scope: keyword.other.intent.fortran
-    - match: '(?<=::)\s*(\w+)'
+    - match: (::)\s*(\w+)
       captures:
-        1: variable.other.fortran
-    - match: '(?i){{firstOnLine}}(type|class){{parenthesisStart}}\s*(\w*){{parenthesisEnd}}'
+        1: punctuation.separator.double-colon.fortran
+        2: variable.other.fortran
+    - match: (?i){{firstOnLine}}(type|class)\s*((\()\s*(\w*)\s*(\)))
       captures:
-        1: storage.type.class.fortran
-        2: entity.name.class.fortran
+        1: keyword.other.fortran
+        2: meta.parens.fortran
+        3: punctuation.section.parens.begin.fortran
+        4: storage.type.class.fortran
+        5: punctuation.section.parens.end.fortran
 
   attribute:
     - match: '(?i)\b{{intrinsicAttribute}}\b'
@@ -382,8 +386,7 @@ contexts:
       pop: true
 
   class-definitions:
-    - match: ^(?i)(?<!\bend\b)\s+\b(type)\b(?!\s*\(|\s*is\b) # not the end of type; not variable specification;
-                                                             # not "type is" construct; must be beginning of declaration
+    - match: ^(?i){{firstOnLine}}\b(type)\b(?!\s*is\b)
       scope: keyword.declaration.class.fortran
       push: class-name
     - match: (?i)\b(procedure|generic|final)\b

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -16,8 +16,8 @@
    endif
 !  ^^^^ keyword.control.fortran
 !
-   end 
-!  ^^^ keyword.control.fortran 
+   end
+!  ^^^ keyword.control.fortran
 !
    read(unit=myUnit, end=200) byte ! Read until end of file, then go to 200
 !       ^^^^ variable.language.io.fortran
@@ -66,8 +66,11 @@
 !                                   ^^^^^^^^^^^^^^ comment.line.fortran
 
    class(myClass), allocatable :: myClassInstance
-!  ^^^^^ storage.type.class.fortran
-!        ^^^^^^^ entity.name.class.fortran
+!  ^^^^^ keyword.other.fortran
+!       ^^^^^^^^^ meta.parens.fortran
+!       ^ punctuation.section.parens.begin.fortran
+!        ^^^^^^^ storage.type.class.fortran
+!               ^ punctuation.section.parens.end.fortran
 !                  ^^^^^^^^^^^ storage.modifier.fortran
 !
    type :: myClass1
@@ -77,10 +80,13 @@
 !  ^^^^^^^^^^^^^^^^ meta.class.declaration.fortran
 !
       class(abstractClass), allocatable :: polymorphicStrategy
-!     ^^^^^ storage.type.class.fortran
+!     ^^^^^ keyword.other.fortran
+!          ^^^^^^^^^^^^^^^ meta.parens.fortran
+!          ^ punctuation.section.parens.begin.fortran
+!           ^^^^^^^^^^^^^ storage.type.class.fortran
+!                        ^ punctuation.section.parens.end.fortran
 !                                          ^^^^^^^^^^^^^^^^^^^ variable.other.fortran
 !                                       ^^ punctuation.separator.double-colon.fortran
-!           ^^^^^^^^^^^^^ entity.name.class.fortran
 !                           ^^^^^^^^^^^ storage.modifier.fortran
 !
 !     ...


### PR DESCRIPTION
`myClass` in `class(myClass) :: myClassInstance` is the class/type name and `class` (and `type`) is a keyword. None of the standard keyword sub-scopes seems to fit really well here, so I chose `keyword.other` for it. I don't know any other language that uses a keyword in a similar manner to denote a type, but it might be useful to have a different scope than `keyword.declaration` here, so it can be distinguished from when `type` is used for class declaration.
The `entity.name.*` scopes - used before for `myClass` here - are usually (with some exceptions) only meant for definitions, but not for the usage of a construct. Personally I don't like the `storage.type` scope for it too much either, because many color schemes highlight it similar to `keyword`. But there doesn't seem to be any better alternative, and since you usefully used `storage.type.intrinsic` for built-in type keywords, they can still be distinguished. (Some syntaxes use `support.class` or `support.type` for user-defined types, but this isn't really correct either.)

Also removed a lookbehind here because they are bad for performance and should be avoided if possible.

Btw, I use `"trim_trailing_white_space_on_save": true` in my settings, so all my PRs might have some whitespace changes if there's trailing whitespace in the file. If you use the "PackageDev" package from Package Control, which I can recommend for working with .sublime-syntax files (better highlighting and some more features), trailing whitespace should be trimmed automatically in .sublime-syntax files.