### PR TITLE
Tweak number patterns and update scopes to latest conventions

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -51,8 +51,8 @@ contexts:
     - include: stop
     - include: function-call
     - include: pointer-symbol
-    - include: match-end 
-    - include: match-variable 
+    - include: match-end
+    - include: match-variable
     - include: omp
 
   eol-pop:
@@ -449,16 +449,18 @@ contexts:
         1: entity.name.class.fortran
 
   numbers:
-    - match: '(\d+)'
-      scope: constant.numeric.fortran
-    - match: '(?i)(?<=\d)(d|e)'
-      scope: constant.numeric.fortran
-    - match: '(?<=\d)(\.)'
-      scope: constant.numeric.fortran
-    - match: '(?<=\d)(\_)(\w+)' # e.g. 1.123_dp, where dp=8
+    - match: (?i)((?:\b\d+(\.)\d*|(\.)\d+)(?:[de][-+]?\d+)?)(_\w+)?
+      scope: meta.number.float.decimal.fortran
       captures:
-        1: punctuation.separator.underscore.fortran
-        2: variable.other.fortran
+        1: constant.numeric.value.fortran
+        2: punctuation.separator.decimal.fortran
+        3: punctuation.separator.decimal.fortran
+        4: constant.numeric.suffix.fortran
+    - match: \b(\d+)(_\w+)?\b
+      scope: meta.number.integer.decimal.fortran
+      captures:
+         1: constant.numeric.value.fortran
+         2: constant.numeric.suffix.fortran
 
   constants:
     - match: (?i)(\.true\.|\.false\.)

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -456,11 +456,16 @@ contexts:
         2: punctuation.separator.decimal.fortran
         3: punctuation.separator.decimal.fortran
         4: constant.numeric.suffix.fortran
-    - match: \b(\d+)(_\w+)?\b
+    - match: (?i)\b(\d+[de]\d+)(_\w+)?
+      scope: meta.number.float.decimal.fortran
+      captures:
+        1: constant.numeric.value.fortran
+        2: constant.numeric.suffix.fortran
+    - match: \b(\d+)(_\w+)?
       scope: meta.number.integer.decimal.fortran
       captures:
-         1: constant.numeric.value.fortran
-         2: constant.numeric.suffix.fortran
+        1: constant.numeric.value.fortran
+        2: constant.numeric.suffix.fortran
 
   constants:
     - match: (?i)(\.true\.|\.false\.)

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -449,18 +449,13 @@ contexts:
         1: entity.name.class.fortran
 
   numbers:
-    - match: (?i)((?:\b\d+(\.)\d*|(\.)\d+)(?:[de][-+]?\d+)?)(_\w+)?
+    - match: (?i)((?:\b\d+(\.)\d*|(\.)\d+)(?:[de][-+]?\d+)?|\b\d+[de][-+]?\d+)(_\w+)?
       scope: meta.number.float.decimal.fortran
       captures:
         1: constant.numeric.value.fortran
         2: punctuation.separator.decimal.fortran
         3: punctuation.separator.decimal.fortran
         4: constant.numeric.suffix.fortran
-    - match: (?i)\b(\d+[de]\d+)(_\w+)?
-      scope: meta.number.float.decimal.fortran
-      captures:
-        1: constant.numeric.value.fortran
-        2: constant.numeric.suffix.fortran
     - match: \b(\d+)(_\w+)?
       scope: meta.number.integer.decimal.fortran
       captures:

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -295,6 +295,8 @@
    1.2345E-10
 !  ^^^^^^^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
 !   ^ punctuation.separator.decimal.fortran
+   1e2
+!  ^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
    1.23_dp
 !  ^^^^^^^ meta.number.float.decimal.fortran
 !  ^^^^ constant.numeric.value.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -16,8 +16,8 @@
    endif
 !  ^^^^ keyword.control.fortran
 !
-   end 
-!  ^^^ keyword.control.fortran 
+   end
+!  ^^^ keyword.control.fortran
 !
    read(unit=myUnit, end=200) byte ! Read until end of file, then go to 200
 !       ^^^^ variable.language.io.fortran
@@ -277,20 +277,29 @@
 !      ^^^^^^^^^keyword.declaration.interface.submodule.fortran
 !
    8
-!  ^ constant.numeric.fortran
-!
+!  ^ meta.number.integer.decimal.fortran constant.numeric.value.fortran
    123
-!  ^^^ constant.numeric.fortran
-!
+!  ^^^ meta.number.integer.decimal.fortran constant.numeric.value.fortran
+   1_8
+!  ^ meta.number.integer.decimal.fortran constant.numeric.value.fortran
+!   ^^ meta.number.integer.decimal.fortran constant.numeric.suffix.fortran
+   123.
+!  ^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
+!     ^ punctuation.separator.decimal.fortran
+   .123
+!  ^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
+!  ^ punctuation.separator.decimal.fortran
    1.0d-12
-!  ^^^^^^^ constant.numeric.fortran
-!
+!  ^^^^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
+!   ^ punctuation.separator.decimal.fortran
    1.2345E-10
-!  ^^^^^^^^^^ constant.numeric.fortran
-!
+!  ^^^^^^^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
+!   ^ punctuation.separator.decimal.fortran
    1.23_dp
-!      ^ punctuation.separator.underscore.fortran
-!       ^^ variable.other.fortran
+!  ^^^^^^^ meta.number.float.decimal.fortran
+!  ^^^^ constant.numeric.value.fortran
+!      ^^^ constant.numeric.suffix.fortran
+!   ^ punctuation.separator.decimal.fortran
 !
    a = minval(b)
 !      ^^^^^^ support.function.intrinsic.fortran
@@ -344,15 +353,15 @@
    do I = 1, 10
 !  ^^ keyword.control.fortran
 !     ^ variable.other.fortran
-!         ^ constant.numeric.fortran
+!         ^ constant.numeric.value.fortran
 !          ^ punctuation.separator.comma.fortran
-!            ^^ constant.numeric.fortran
+!            ^^ constant.numeric.value.fortran
 !
       evenNumber = evenNumber + 2*I
 !     ^^^^^^^^^^ variable.other.fortran
 !                  ^^^^^^^^^^ variable.other.fortran
 !                                 ^ variable.other.fortran
-!                               ^ constant.numeric.fortran
+!                               ^ constant.numeric.value.fortran
    enddo
 !  ^^^^^ keyword.control.fortran
 !
@@ -661,13 +670,13 @@ end program myProgram
 !  ^^^^^^^ storage.type.intrinsic.fortran
 !             ^ variable.other.fortran
 !                        ^ keyword.operator.arithmetic.fortran
-!                         ^ constant.numeric.fortran
+!                         ^ constant.numeric.value.fortran
 !                          ^ punctuation.separator.single-colon.fortran
-!                           ^ constant.numeric.fortran
+!                           ^ constant.numeric.value.fortran
 !                            ^ punctuation.separator.comma.fortran
-!               ^ constant.numeric.fortran
-!                 ^ constant.numeric.fortran
-!                   ^^ constant.numeric.fortran
+!               ^ constant.numeric.value.fortran
+!                 ^ constant.numeric.value.fortran
+!                   ^^ constant.numeric.value.fortran
 !                ^ punctuation.separator.comma.fortran
 !                  ^ punctuation.separator.single-colon.fortran
 !
@@ -682,7 +691,7 @@ end program myProgram
 !       ^^^^^^^^^^ support.function.intrinsic.fortran
 !                             ^^^^ keyword.control.fortran
 !                                  ^^^^^^ keyword.control.fortran
-!                                          ^ constant.numeric.fortran
+!                                          ^ constant.numeric.value.fortran
 !
 !
    type(t) :: myValue[*]
@@ -706,7 +715,7 @@ end program myProgram
 !  ^^^^^^^^ support.function.subroutine.fortran
 !            ^^ storage.type.class.fortran
 !                 ^^^^ variable.function.fortran
-!                       ^^ constant.numeric.fortran
+!                       ^^ constant.numeric.value.fortran
 !
    result = thisFunction ()
 !  ^^^^^^ variable.other.fortran
@@ -772,11 +781,11 @@ end program myProgram
 !         ^^^^^^^^ entity.name.interface.module.fortran
 !
    stop 98
-!       ^^ constant.numeric.fortran
+!       ^^ constant.numeric.value.fortran
 !  ^^^^ keyword.control.fortran
 !
    error stop 1
-!             ^ constant.numeric.fortran
+!             ^ constant.numeric.value.fortran
 !  ^^^^^ keyword.control.fortran
 !        ^^^^ keyword.control.fortran
 !
@@ -786,7 +795,7 @@ end program myProgram
 !        ^^^^ keyword.control.fortran
 !
    error stop 1, quiet=(a .eq. b)
-!             ^ constant.numeric.fortran
+!             ^ constant.numeric.value.fortran
 !                ^^^^^ keyword.control.fortran
 !  ^^^^^ keyword.control.fortran
 !        ^^^^ keyword.control.fortran


### PR DESCRIPTION
Tweaked the regex patterns to correctly detect some more valid numbers, and adjusted the scope names to the latest conventions (used in all the default syntaxes now).

*Note*: I removed the `punctuation` scope for the `_` in numbers here, because I don't find it very useful and there isn't any comparable instance of it in other syntaxes that I know of. I would say the `_dp` is rather a part of the number token itself, and therefore has `constant.number.suffix` now. The highlighting for this scope can be adjusted/customized in the color scheme for number suffixes in all languages (assuming the latest syntax definitions are used), if it should have a different color from the rest of the number.
