### PR TITLE
Fix some missing word boundaries after keywords

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -130,14 +130,18 @@ contexts:
 
   control:
     - include: comments
-    - match: (?i)^\s*\b(end)\s*(if|do|select)
+    - match: (?i){{firstOnLine}}(end)\s*(if|do|select)\b
       captures:
         1: keyword.control.fortran
         2: keyword.control.fortran
       push: seek-conditional-label
-    - match: (?i)(end)(?=if|do)
-      scope: keyword.control.fortran
-    - match: (?i)\b(then|exit|cycle)
+    - match: (?i)(;)\s*(end)\s*(if|do)\b
+      captures:
+        1: punctuation.terminator.fortran
+        2: keyword.control.fortran
+        3: keyword.control.fortran
+      push: seek-conditional-label
+    - match: (?i)\b(then|exit|cycle)\b
       scope: keyword.control.fortran
       push: seek-conditional-label
     - match: (?i)(?<=else)(?!\s*if)
@@ -239,8 +243,10 @@ contexts:
     - match: (?i)\b(impure|pure|elemental|non\_recursive|recursive)\b
       scope: storage.modifier.function.prefix.fortran
 
-    - match: (?i)(implicit none)
-      scope: keyword.control.fortran
+    - match: (?i)\b(implicit)(?:\s+(none))?\b
+      captures:
+        1: keyword.control.fortran
+        2: keyword.control.fortran
 
     - match: '(?i)\b(module)(?=\s+procedure\b)'
       scope: storage.modifier.function.prefix.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -53,9 +53,18 @@
    enddo
 !  ^^^^^ keyword.control.fortran
 !
+   enddoo
+!  ^^^^^ - keyword
+!
    elsei ! should not recognize 'else' in 'elsei'
 !  ^^^^ - keyword.control.fortran
 !
+   exitflag = 0
+!  ^^^^ - keyword
+!
+   if (.true.) then
+      print*, 'test'; endif
+!                     ^^^^^ keyword.control.fortran
 !
    real(dp), intent(in) :: myReal ! a side-comment
 !  ^^^^ storage.type.intrinsic.fortran
@@ -231,7 +240,8 @@
 !                    ^^^^^^^ entity.name.function.fortran
 !
       implicit none
-!     ^^^^^^^^^^^^^ keyword.control.fortran
+!     ^^^^^^^^ keyword.control.fortran
+!              ^^^^ keyword.control.fortran
 !
    end subroutine doStuff
 !


### PR DESCRIPTION
The syntax tests should be self-explanatory.

The pattern for the `implicit` statement could be improved to recognize other forms than `implicit none`, and maybe there is some room for optimizations how to detect and scope keywords in general, but for now this should fix a few cases with bad highlighting that I noticed. 