### PR TITLE
Remove obsolete rule for +/- sign in number exponents

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -106,9 +106,6 @@ contexts:
       scope: keyword.operator.comparison.fortran
     - match: (?i)(\.and\.|\.or\.|\.ne\.|\.lt\.|\.le\.|\.gt\.|\.ge\.|\.eq\.|\.not\.)
       scope: keyword.operator.word.fortran
-    - match: (?i)(?<=d|e)(\-|\+)(?=\d) # - and + is not arithmetic
-                                       # in scientific notation (1.0d-2)
-      scope: constant.numeric.fortran
     - match: (\*|\+|-)
       scope: keyword.operator.arithmetic.fortran
     - match: (\/)(?!/)

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -303,6 +303,9 @@
 !      ^^^ constant.numeric.suffix.fortran
 !   ^ punctuation.separator.decimal.fortran
 !
+   dplusone = d+1
+!              ^ keyword.operator.arithmetic.fortran - constant.numeric
+!
    a = minval(b)
 !      ^^^^^^ support.function.intrinsic.fortran
 !


### PR DESCRIPTION
This rule is not used anymore after #37 and I missed to remove it in that PR.