### PR TITLE
Fix tests

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -30,7 +30,6 @@ variables:
 contexts:
   main:
     - include: attribute
-    - include: modules
     - include: interfaces
     - include: class-definitions
     - include: control
@@ -46,6 +45,7 @@ contexts:
     - include: types
     - include: operators
     - include: procedures
+    - include: modules
     - include: strings
     - include: continuation
     - include: separators


### PR DESCRIPTION
Fix #42.

Not sure what exactly went wrong there with that last merge. Anyways, this should fix it.

I think it could be useful to move a few patterns out of the "types" and "procedures" contexts:
* `in|out|inout` could be moved from "types" into "constants" and maybe use the scope `support.constant` for them?
* the `intrinsicFunction`s and `intrinsicSubroutine`s can be prepended in the "function-call" context

With that, "types", "procedures" and "modules" could be moved back into "main", because the rest of these contexts describe procedure, module or variable declarations and should never occur withing parentheses or brackets.

But I can do that in a later pull request.