### PR TITLE
Fix incorrect type declaration bug

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -427,7 +427,7 @@ contexts:
       pop: true
 
   class-definitions:
-    - match: ^(?i){{firstOnLine}}\b(type)\b(?!\s*is\b)
+    - match: ^(?i){{firstOnLine}}\b(type)\b(?!\s*\(|\s*is\b)
       scope: keyword.declaration.class.fortran
       push: class-name
     - match: (?i)\b(procedure|generic|final)\b

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -63,6 +63,22 @@
 !     ^^^^^ keyword.control.fortran
 !                        ^^^^^^^^^^^^^^ comment.line.fortran
 !
+   type(interval) :: myInterval ! object instance declaration, not type definition
+!  ^^^^ keyword.other.fortran
+!      ^ meta.parens.fortran punctuation.section.parens.begin.fortran
+!       ^^^^^^^^ meta.parens.fortran storage.type.class.fortran
+!               ^ meta.parens.fortran punctuation.section.parens.end.fortran
+!                 ^^ punctuation.separator.double-colon.fortran
+!                    ^^^^^^^^^^ variable.other.fortran
+!
+   type (interval) :: myInterval ! object instance declaration, not type definition
+!  ^^^^ keyword.other.fortran
+!       ^ meta.parens.fortran punctuation.section.parens.begin.fortran
+!        ^^^^^^^^ meta.parens.fortran storage.type.class.fortran
+!                ^ meta.parens.fortran punctuation.section.parens.end.fortran
+!                  ^^ punctuation.separator.double-colon.fortran
+!                     ^^^^^^^^^^ variable.other.fortran
+!
    enddo
 !  ^^^^^ keyword.control.fortran
 !


### PR DESCRIPTION
When using the `type` keyword we have to check for a beginning parenthesis as well, since `type(interval) :: myInterval` is a declaration of an object instance and not a type definition for myInterval. I've added some tests to make sure this is tested in the future.