### PR TITLE
Release/1.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Sarai D. Folkestad and Eirik F. Kjønstad 
+Copyright (c) 2020-2021 by the authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -427,7 +427,7 @@ contexts:
       pop: true
 
   class-definitions:
-    - match: ^(?i){{firstOnLine}}\b(type)\b(?!\s*is\b)
+    - match: ^(?i){{firstOnLine}}\b(type)\b(?!\s*\(|\s*is\b)
       scope: keyword.declaration.class.fortran
       push: class-name
     - match: (?i)\b(procedure|generic|final)\b

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -51,8 +51,8 @@ contexts:
     - include: stop
     - include: function-call
     - include: pointer-symbol
-    - include: match-end 
-    - include: match-variable 
+    - include: match-end
+    - include: match-variable
     - include: omp
 
   eol-pop:
@@ -449,16 +449,18 @@ contexts:
         1: entity.name.class.fortran
 
   numbers:
-    - match: '(\d+)'
-      scope: constant.numeric.fortran
-    - match: '(?i)(?<=\d)(d|e)'
-      scope: constant.numeric.fortran
-    - match: '(?<=\d)(\.)'
-      scope: constant.numeric.fortran
-    - match: '(?<=\d)(\_)(\w+)' # e.g. 1.123_dp, where dp=8
+    - match: (?i)((?:\b\d+(\.)\d*|(\.)\d+)(?:[de][-+]?\d+)?|\b\d+[de][-+]?\d+)(_\w+)?
+      scope: meta.number.float.decimal.fortran
       captures:
-        1: punctuation.separator.underscore.fortran
-        2: variable.other.fortran
+        1: constant.numeric.value.fortran
+        2: punctuation.separator.decimal.fortran
+        3: punctuation.separator.decimal.fortran
+        4: constant.numeric.suffix.fortran
+    - match: \b(\d+)(_\w+)?
+      scope: meta.number.integer.decimal.fortran
+      captures:
+        1: constant.numeric.value.fortran
+        2: constant.numeric.suffix.fortran
 
   constants:
     - match: (?i)(\.true\.|\.false\.)

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -511,7 +511,7 @@ contexts:
       scope: constant.language.fortran
 
   class-accessing:
-    - match: '(\w+)\s*(?=\%|\[.*\]\(.*\)\%|\(.*\)\%|\[.*\]\%)'
+    - match: '\w+(?=(?:\s*\[.*\])?(?:\s*\([^(]*\))?\s*\%)'
       scope: storage.type.class.fortran
 
   function-call:

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -124,13 +124,17 @@ contexts:
       scope: storage.type.intrinsic.fortran
     - match: '(?i)\b(in|out|inout)\b'
       scope: keyword.other.intent.fortran
-    - match: '(?<=::)\s*(\w+)'
+    - match: (::)\s*(\w+)
       captures:
-        1: variable.other.fortran
-    - match: '(?i){{firstOnLine}}(type|class){{parenthesisStart}}\s*(\w*){{parenthesisEnd}}'
+        1: punctuation.separator.double-colon.fortran
+        2: variable.other.fortran
+    - match: (?i){{firstOnLine}}(type|class)\s*((\()\s*(\w*)\s*(\)))
       captures:
-        1: storage.type.class.fortran
-        2: entity.name.class.fortran
+        1: keyword.other.fortran
+        2: meta.parens.fortran
+        3: punctuation.section.parens.begin.fortran
+        4: storage.type.class.fortran
+        5: punctuation.section.parens.end.fortran
 
   attribute:
     - match: '(?i)\b{{intrinsicAttribute}}\b'
@@ -424,8 +428,7 @@ contexts:
       pop: true
 
   class-definitions:
-    - match: ^(?i)(?<!\bend\b)\s+\b(type)\b(?!\s*\(|\s*is\b) # not the end of type; not variable specification;
-                                                             # not "type is" construct; must be beginning of declaration
+    - match: ^(?i){{firstOnLine}}\b(type)\b(?!\s*is\b)
       scope: keyword.declaration.class.fortran
       push: class-name
     - match: (?i)\b(procedure|generic|final)\b

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -106,9 +106,6 @@ contexts:
       scope: keyword.operator.comparison.fortran
     - match: (?i)(\.and\.|\.or\.|\.ne\.|\.lt\.|\.le\.|\.gt\.|\.ge\.|\.eq\.|\.not\.)
       scope: keyword.operator.word.fortran
-    - match: (?i)(?<=d|e)(\-|\+)(?=\d) # - and + is not arithmetic
-                                       # in scientific notation (1.0d-2)
-      scope: constant.numeric.fortran
     - match: (\*|\+|-)
       scope: keyword.operator.arithmetic.fortran
     - match: (\/)(?!/)

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -30,7 +30,6 @@ variables:
 contexts:
   main:
     - include: attribute
-    - include: modules
     - include: interfaces
     - include: class-definitions
     - include: control
@@ -46,6 +45,7 @@ contexts:
     - include: types
     - include: operators
     - include: procedures
+    - include: modules
     - include: strings
     - include: continuation
     - include: separators

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -51,7 +51,8 @@ contexts:
     - include: stop
     - include: function-call
     - include: pointer-symbol
-    - include: match-variable
+    - include: match-end 
+    - include: match-variable 
     - include: omp
 
   eol-pop:
@@ -331,7 +332,7 @@ contexts:
     - match: '(?i)\b({{intrinsicIO}})\b'
       captures:
         1: variable.function.subroutine.intrinsic.io.fortran
-    - match: '(?i)\b({{intrinsicIOArguments}})\b'
+    - match: '(?i)\b({{intrinsicIOArguments}})\b\s*(?=\=)'
       captures:
         1: variable.language.io.fortran
 
@@ -534,6 +535,10 @@ contexts:
         - match: '{{firstOnLine}}(?i)(\!\$omp)'
           scope: keyword.control.directive.fortran
           pop: true
+
+  match-end:
+    - match: \bend\b
+      scope: keyword.control.fortran
 
   match-variable:
     - match: ({{variableMatch}})

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -29,31 +29,36 @@ variables:
 
 contexts:
   main:
-    - include: preprocessing
-    - include: comments
-    - include: types
     - include: attribute
-    - include: operators
-    - include: procedures
     - include: modules
     - include: interfaces
     - include: class-definitions
     - include: control
+    - include: coarray
+    - include: program
+    - include: stop
+    - include: omp
+    - include: expressions
+
+  expressions:
+    - include: comments
+    - include: preprocessing
+    - include: types
+    - include: operators
+    - include: procedures
     - include: strings
     - include: continuation
-    - include: coarray
     - include: separators
     - include: numbers
     - include: constants
-    - include: program
     - include: class-accessing
     - include: io
-    - include: stop
     - include: function-call
     - include: pointer-symbol
     - include: match-end
     - include: match-variable
-    - include: omp
+    - include: parens
+    - include: brackets
 
   eol-pop:
     - match: (?=\s*[!\n])
@@ -77,6 +82,40 @@ contexts:
       - meta_scope: comment.line.fortran
       - match: \n
         pop: true
+
+  parens:
+    - match: \(/
+      scope: punctuation.section.parens.begin.fortran
+      push:
+        - meta_scope: meta.parens.fortran
+        - include: line-continuation
+        - include: eol-pop
+        - match: /\)
+          scope: punctuation.section.parens.end.fortran
+          pop: true
+        - include: expressions
+    - match: \(
+      scope: punctuation.section.parens.begin.fortran
+      push:
+        - meta_scope: meta.parens.fortran
+        - include: line-continuation
+        - include: eol-pop
+        - match: \)
+          scope: punctuation.section.parens.end.fortran
+          pop: true
+        - include: expressions
+
+  brackets:
+    - match: \[
+      scope: punctuation.section.brackets.begin.fortran
+      push:
+        - meta_scope: meta.brackets.fortran
+        - include: line-continuation
+        - include: eol-pop
+        - match: \]
+          scope: punctuation.section.brackets.end.fortran
+          pop: true
+        - include: expressions
 
   types:
     - match: '(?i)\b{{intrinsicType}}\b(?=.*(function))' # type of return value in function
@@ -550,10 +589,9 @@ contexts:
       scope: variable.other.fortran
 
   preprocessing:
-    - match: '{{firstOnLine}}(\#)'
-      scope: keyword.control.directive.fortran
-    - match: '(?i)(?<=\#)({{fppCommands}})'
-      scope: keyword.control.directive.fortran
+    - match: '(?i){{firstOnLine}}(\#{{fppCommands}})'
+      captures:
+        1: keyword.control.directive.fortran
 
   program:
     - match: (?i){{firstOnLine}}(program)(?:\s+(\w+))?\b

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -4,7 +4,6 @@
 # Modern Fortran syntax - Sublime Text syntax highlighting for modern Fortran code
 #
 # Copyright (c) 2020-2021 by the authors
-# Sarai D. Folkestad and Eirik F. Kjønstad
 #
 name: Modern-Fortran
 file_extensions: [F90,F95,F03,F08,F18,f90,f95,f03,f08,f18]

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -22,7 +22,6 @@ variables:
   parenthesisStart: '\(\s*'
   parenthesisEnd: '\s*\)'
   variableMatch: '[A-Za-z_][A-Za-z_0-9]*'
-  s: '[^\S\r\n]' # blank but not newline
   ompDirectives: '(end|parallel|do|simd|single|target|update|workshare|declare|sections|distribute|teams|task|taskyield|master|critical|barrier|taskwait|taskgroup|atomic|flush|ordered|cancel|cancellation point|reduction)'
   ompIntrinsics: (omp_set_num_threads|omp_get_num_threads|omp_get_max_threads|omp_get_thread_num|omp_get_num_procs|omp_in_parallel|omp_set_dynamic|omp_get_dynamic|omp_get_cancellation|omp_set_nested|omp_get_nested|omp_set_schedule|omp_get_schedule|omp_get_thread_limit|omp_set_max_active_levels|omp_get_max_active_levels|omp_get_level|omp_get_ancestor_thread_num|omp_get_team_size|omp_get_active_level|omp_in_final|omp_get_proc_bind|omp_set_default_device|omp_get_default_device|omp_get_num_devices|omp_get_num_teams|omp_get_team_num|omp_is_initial_device|omp_init_lock|omp_init_nest_lock|omp_destroy_lock|omp_destroy_nest_lock|omp_set_lock|omp_set_nest_lock|omp_unset_lock|omp_unset_nest_lock|omp_test_lock|omp_test_nest_lock|omp_get_wtime|omp_get_wtick)
   ompClauses: (default|shared|private|firstprivate|lastprivate|linear|reduction|copyin|copyprivate|map|tofrom|safelen|collapse|simdlen|aligned|uniform|Inbrach|notinbranch)
@@ -86,7 +85,7 @@ contexts:
     - match: '(?i)\b(in|out|inout)\b'
       scope: keyword.other.intent.fortran
     - match: '(?<=::)\s*(\w+)'
-      captures: 
+      captures:
         1: variable.other.fortran
     - match: '(?i){{firstOnLine}}(type|class){{parenthesisStart}}\s*(\w*){{parenthesisEnd}}'
       captures:
@@ -130,7 +129,7 @@ contexts:
 
   control:
     - include: comments
-    - match: (?i)^{{s}}*\b(end){{s}}*(if|do|select)
+    - match: (?i)^\s*\b(end)\s*(if|do|select)
       captures:
         1: keyword.control.fortran
         2: keyword.control.fortran
@@ -242,11 +241,14 @@ contexts:
     - match: (?i)(implicit none)
       scope: keyword.control.fortran
 
-    - match: '(?i)\b(module)\b\s+(?=function|subroutine|procedure)'
+    - match: '(?i)\b(module)(?=\s+procedure\b)'
       scope: storage.modifier.function.prefix.fortran
 
-    - match: (?i)\bfunction\b
-      scope: meta.function.declaration.fortran keyword.declaration.function.fortran
+    - match: (?i)(?:\b(module)\s+)?\b(function)\b
+      scope: meta.function.declaration.fortran
+      captures:
+         1: storage.modifier.function.prefix.fortran
+         2: keyword.declaration.function.fortran
       push:
         - meta_content_scope: meta.function.declaration.fortran
         - include: line-continuation
@@ -289,8 +291,10 @@ contexts:
                           scope: punctuation.section.parens.end.fortran
                           pop: true
 
-    - match: (?i)\bsubroutine\b
-      scope: keyword.declaration.function.fortran
+    - match: (?i)(?:\b(module)\s+)?\b(subroutine)\b
+      captures:
+        1: storage.modifier.function.prefix.fortran
+        2: keyword.declaration.function.fortran
       push:
         - meta_scope: meta.function.declaration.fortran
         - include: line-continuation
@@ -340,23 +344,25 @@ contexts:
       scope: keyword.control.fortran
 
   modules:
-    - match: (?i)^{{s}}*\b(module)\b{{s}}+(\w+)\b{{s}}*$
+    - match: (?i)\b(module)(?:\s+(\w+))?\b
       scope: meta.module.declaration.fortran
       captures:
         1: keyword.declaration.interface.module.fortran
         2: entity.name.interface.module.fortran
-    - match: (?i)^{{s}}*\b(end)\b{{s}}+\b(module)\b{{s}}+(\w*)
+    - match: (?i){{firstOnLine}}(end)\s+(module)(?:\s+(\w+))?\b
       captures:
         1: keyword.declaration.interface.module.fortran
         2: keyword.declaration.interface.module.fortran
         3: entity.name.interface.module.fortran
-    - match: (?i)^{{s}}*\b(submodule)\b{{s}}+\((\w+)\){{s}}+(\w+){{s}}*$
+    - match: (?i){{firstOnLine}}(submodule)(?:\s+(\()\s*(\w+)\s*(\))(?:\s+(\w+))?)?
       scope: meta.submodule.declaration.fortran
       captures:
         1: keyword.declaration.interface.submodule.fortran
-        2: entity.name.interface.inherited-module.fortran
-        3: entity.name.interface.submodule.fortran
-    - match: (?i)^{{s}}*\b(end)\b{{s}}+\b(submodule)\b{{s}}+(\w*)
+        2: punctuation.section.parens.begin.fortran
+        3: entity.name.interface.inherited-module.fortran
+        4: punctuation.section.parens.end.fortran
+        5: entity.name.interface.submodule.fortran
+    - match: (?i){{firstOnLine}}(end)\s+(submodule)(?:\s+(\w+))?\b
       captures:
         1: keyword.declaration.interface.submodule.fortran
         2: keyword.declaration.interface.submodule.fortran
@@ -472,7 +478,7 @@ contexts:
     - match: (?i)\b(interface)\b
       scope: keyword.declaration.interface.interface.fortran
     - match: '(?i)(?<=interface)\s+(\w*)'
-      captures: 
+      captures:
         1: entity.name.interface.interface.fortran
     - match: (?i)\b(include)\b
       scope: keyword.control.import.fortran
@@ -540,12 +546,12 @@ contexts:
       scope: keyword.control.directive.fortran
 
   program:
-    - match: (?i)^{{s}}*\b(program)\b{{s}}+(\w+)\b{{s}}*$
+    - match: (?i){{firstOnLine}}(program)(?:\s+(\w+))?\b
       scope: meta.program.declaration.fortran
       captures:
         1: keyword.declaration.program.fortran
         2: entity.name.program.fortran
-    - match: (?i)^{{s}}*(end)\b{{s}}+\b(program)\b{{s}}+(\w*)\b{{s}}*$
+    - match: (?i){{firstOnLine}}(end)\s+(program)(?:\s+(\w+))?\b
       captures:
         1: keyword.declaration.program.fortran
         2: keyword.declaration.program.fortran

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -130,14 +130,18 @@ contexts:
 
   control:
     - include: comments
-    - match: (?i)^\s*\b(end)\s*(if|do|select)
+    - match: (?i){{firstOnLine}}(end)\s*(if|do|select)\b
       captures:
         1: keyword.control.fortran
         2: keyword.control.fortran
       push: seek-conditional-label
-    - match: (?i)(end)(?=if|do)
-      scope: keyword.control.fortran
-    - match: (?i)\b(then|exit|cycle)
+    - match: (?i)(;)\s*(end)\s*(if|do)\b
+      captures:
+        1: punctuation.terminator.fortran
+        2: keyword.control.fortran
+        3: keyword.control.fortran
+      push: seek-conditional-label
+    - match: (?i)\b(then|exit|cycle)\b
       scope: keyword.control.fortran
       push: seek-conditional-label
     - match: (?i)(?<=else)(?!\s*if)
@@ -239,8 +243,10 @@ contexts:
     - match: (?i)\b(impure|pure|elemental|non\_recursive|recursive)\b
       scope: storage.modifier.function.prefix.fortran
 
-    - match: (?i)(implicit none)
-      scope: keyword.control.fortran
+    - match: (?i)\b(implicit)(?:\s+(none))?\b
+      captures:
+        1: keyword.control.fortran
+        2: keyword.control.fortran
 
     - match: '(?i)\b(module)(?=\s+procedure\b)'
       scope: storage.modifier.function.prefix.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -238,10 +238,19 @@
 !         ^^^^^^^^ entity.name.interface.module.fortran
 !  ^^^^^^^^^^^^^^^ meta.module.declaration.fortran
 !
+   module myModule ! comment
+!  ^^^^^^ keyword.declaration.interface.module.fortran
+!         ^^^^^^^^ entity.name.interface.module.fortran
+!  ^^^^^^^^^^^^^^^ meta.module.declaration.fortran
+!
    end module myModule
 !  ^^^ keyword.declaration.interface.module.fortran
 !      ^^^^^^ keyword.declaration.interface.module.fortran
 !             ^^^^^^^^ entity.name.interface.module.fortran - meta.module.declaration.fortran
+!
+   end module
+!  ^^^ keyword.declaration.interface.module.fortran
+!      ^^^^^^ keyword.declaration.interface.module.fortran
 !
    submodule (moduleName) submoduleName
 !  ^^^^^^^^^ keyword.declaration.interface.submodule.fortran
@@ -255,6 +264,11 @@
 !
    end submodule ! just empty end-name also allowed
 !      ^^^^^^^^^ keyword.declaration.interface.submodule.fortran
+!
+   end submodule
+!  ^^^ keyword.declaration.interface.submodule.fortran
+!      ^^^^^^^^^keyword.declaration.interface.submodule.fortran
+!
    8
 !  ^ constant.numeric.fortran
 !

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -437,6 +437,12 @@
 !                ^ punctuation.accessor.fortran
 !                 ^^^^^^^^^^^^^^ variable.other.fortran
 !
+   myVar = object % objectVariable
+!          ^^^^^^ storage.type.class.fortran
+!                ^ - storage.type
+!                 ^ punctuation.accessor.fortran
+!                   ^^^^^^^^^^^^^^ variable.other.fortran
+!
    myVar = object%objectVariable%getStuff(a, b)
 !          ^^^^^^ storage.type.class.fortran
 !                 ^^^^^^^^^^^^^^ storage.type.class.fortran
@@ -447,6 +453,17 @@
 !                 ^^^^^^^^^^^^^^ variable.function.fortran
 !                                         ^^^^^^^^^^^ storage.type.class.fortran
 !                                                     ^^^^^^^^ variable.other.fortran
+!
+   result = foo(object%member)
+!           ^^^ variable.function.fortran
+!               ^^^^^^ storage.type.class.fortran
+!                      ^^^^^^ variable.other.fortran
+!
+   result = foo(object(k)%member)
+!           ^^^ variable.function.fortran
+!               ^^^^^^ storage.type.class.fortran
+!                      ^ variable.other.fortran
+!                         ^^^^^^ variable.other.fortran
 !
    call object%calculateStuff()
 !       ^^^^^^ storage.type.class.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -16,6 +16,13 @@
    endif
 !  ^^^^ keyword.control.fortran
 !
+   end 
+!  ^^^ keyword.control.fortran 
+!
+   read(unit=myUnit, end=200) byte ! Read until end of file, then go to 200
+!       ^^^^ variable.language.io.fortran
+!                    ^^^ variable.language.io.fortran
+!
    a == b .and. c
 !    ^^ keyword.operator.comparison.fortran
 !         ^^^^^ keyword.operator.word.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -53,9 +53,18 @@
    enddo
 !  ^^^^^ keyword.control.fortran
 !
+   enddoo
+!  ^^^^^ - keyword
+!
    elsei ! should not recognize 'else' in 'elsei'
 !  ^^^^ - keyword.control.fortran
 !
+   exitflag = 0
+!  ^^^^ - keyword
+!
+   if (.true.) then
+      print*, 'test'; endif
+!                     ^^^^^ keyword.control.fortran
 !
    real(dp), intent(in) :: myReal ! a side-comment
 !  ^^^^ storage.type.intrinsic.fortran
@@ -231,7 +240,8 @@
 !                    ^^^^^^^ entity.name.function.fortran
 !
       implicit none
-!     ^^^^^^^^^^^^^ keyword.control.fortran
+!     ^^^^^^^^ keyword.control.fortran
+!              ^^^^ keyword.control.fortran
 !
    end subroutine doStuff
 !

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -88,8 +88,11 @@
 !                                   ^^^^^^^^^^^^^^ comment.line.fortran
 
    class(myClass), allocatable :: myClassInstance
-!  ^^^^^ storage.type.class.fortran
-!        ^^^^^^^ entity.name.class.fortran
+!  ^^^^^ keyword.other.fortran
+!       ^^^^^^^^^ meta.parens.fortran
+!       ^ punctuation.section.parens.begin.fortran
+!        ^^^^^^^ storage.type.class.fortran
+!               ^ punctuation.section.parens.end.fortran
 !                  ^^^^^^^^^^^ storage.modifier.fortran
 !
    type :: myClass1
@@ -99,10 +102,13 @@
 !  ^^^^^^^^^^^^^^^^ meta.class.declaration.fortran
 !
       class(abstractClass), allocatable :: polymorphicStrategy
-!     ^^^^^ storage.type.class.fortran
+!     ^^^^^ keyword.other.fortran
+!          ^^^^^^^^^^^^^^^ meta.parens.fortran
+!          ^ punctuation.section.parens.begin.fortran
+!           ^^^^^^^^^^^^^ storage.type.class.fortran
+!                        ^ punctuation.section.parens.end.fortran
 !                                          ^^^^^^^^^^^^^^^^^^^ variable.other.fortran
 !                                       ^^ punctuation.separator.double-colon.fortran
-!           ^^^^^^^^^^^^^ entity.name.class.fortran
 !                           ^^^^^^^^^^^ storage.modifier.fortran
 !
 !     ...

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -16,8 +16,8 @@
    endif
 !  ^^^^ keyword.control.fortran
 !
-   end 
-!  ^^^ keyword.control.fortran 
+   end
+!  ^^^ keyword.control.fortran
 !
    read(unit=myUnit, end=200) byte ! Read until end of file, then go to 200
 !       ^^^^ variable.language.io.fortran
@@ -277,20 +277,31 @@
 !      ^^^^^^^^^keyword.declaration.interface.submodule.fortran
 !
    8
-!  ^ constant.numeric.fortran
-!
+!  ^ meta.number.integer.decimal.fortran constant.numeric.value.fortran
    123
-!  ^^^ constant.numeric.fortran
-!
+!  ^^^ meta.number.integer.decimal.fortran constant.numeric.value.fortran
+   1_8
+!  ^ meta.number.integer.decimal.fortran constant.numeric.value.fortran
+!   ^^ meta.number.integer.decimal.fortran constant.numeric.suffix.fortran
+   123.
+!  ^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
+!     ^ punctuation.separator.decimal.fortran
+   .123
+!  ^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
+!  ^ punctuation.separator.decimal.fortran
    1.0d-12
-!  ^^^^^^^ constant.numeric.fortran
-!
+!  ^^^^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
+!   ^ punctuation.separator.decimal.fortran
    1.2345E-10
-!  ^^^^^^^^^^ constant.numeric.fortran
-!
+!  ^^^^^^^^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
+!   ^ punctuation.separator.decimal.fortran
+   1e2
+!  ^^^ meta.number.float.decimal.fortran constant.numeric.value.fortran
    1.23_dp
-!      ^ punctuation.separator.underscore.fortran
-!       ^^ variable.other.fortran
+!  ^^^^^^^ meta.number.float.decimal.fortran
+!  ^^^^ constant.numeric.value.fortran
+!      ^^^ constant.numeric.suffix.fortran
+!   ^ punctuation.separator.decimal.fortran
 !
    a = minval(b)
 !      ^^^^^^ support.function.intrinsic.fortran
@@ -344,15 +355,15 @@
    do I = 1, 10
 !  ^^ keyword.control.fortran
 !     ^ variable.other.fortran
-!         ^ constant.numeric.fortran
+!         ^ constant.numeric.value.fortran
 !          ^ punctuation.separator.comma.fortran
-!            ^^ constant.numeric.fortran
+!            ^^ constant.numeric.value.fortran
 !
       evenNumber = evenNumber + 2*I
 !     ^^^^^^^^^^ variable.other.fortran
 !                  ^^^^^^^^^^ variable.other.fortran
 !                                 ^ variable.other.fortran
-!                               ^ constant.numeric.fortran
+!                               ^ constant.numeric.value.fortran
    enddo
 !  ^^^^^ keyword.control.fortran
 !
@@ -661,13 +672,13 @@ end program myProgram
 !  ^^^^^^^ storage.type.intrinsic.fortran
 !             ^ variable.other.fortran
 !                        ^ keyword.operator.arithmetic.fortran
-!                         ^ constant.numeric.fortran
+!                         ^ constant.numeric.value.fortran
 !                          ^ punctuation.separator.single-colon.fortran
-!                           ^ constant.numeric.fortran
+!                           ^ constant.numeric.value.fortran
 !                            ^ punctuation.separator.comma.fortran
-!               ^ constant.numeric.fortran
-!                 ^ constant.numeric.fortran
-!                   ^^ constant.numeric.fortran
+!               ^ constant.numeric.value.fortran
+!                 ^ constant.numeric.value.fortran
+!                   ^^ constant.numeric.value.fortran
 !                ^ punctuation.separator.comma.fortran
 !                  ^ punctuation.separator.single-colon.fortran
 !
@@ -682,7 +693,7 @@ end program myProgram
 !       ^^^^^^^^^^ support.function.intrinsic.fortran
 !                             ^^^^ keyword.control.fortran
 !                                  ^^^^^^ keyword.control.fortran
-!                                          ^ constant.numeric.fortran
+!                                          ^ constant.numeric.value.fortran
 !
 !
    type(t) :: myValue[*]
@@ -706,7 +717,7 @@ end program myProgram
 !  ^^^^^^^^ support.function.subroutine.fortran
 !            ^^ storage.type.class.fortran
 !                 ^^^^ variable.function.fortran
-!                       ^^ constant.numeric.fortran
+!                       ^^ constant.numeric.value.fortran
 !
    result = thisFunction ()
 !  ^^^^^^ variable.other.fortran
@@ -772,11 +783,11 @@ end program myProgram
 !         ^^^^^^^^ entity.name.interface.module.fortran
 !
    stop 98
-!       ^^ constant.numeric.fortran
+!       ^^ constant.numeric.value.fortran
 !  ^^^^ keyword.control.fortran
 !
    error stop 1
-!             ^ constant.numeric.fortran
+!             ^ constant.numeric.value.fortran
 !  ^^^^^ keyword.control.fortran
 !        ^^^^ keyword.control.fortran
 !
@@ -786,7 +797,7 @@ end program myProgram
 !        ^^^^ keyword.control.fortran
 !
    error stop 1, quiet=(a .eq. b)
-!             ^ constant.numeric.fortran
+!             ^ constant.numeric.value.fortran
 !                ^^^^^ keyword.control.fortran
 !  ^^^^^ keyword.control.fortran
 !        ^^^^ keyword.control.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -63,6 +63,22 @@
 !     ^^^^^ keyword.control.fortran
 !                        ^^^^^^^^^^^^^^ comment.line.fortran
 !
+   type(interval) :: myInterval ! object instance declaration, not type definition
+!  ^^^^ keyword.other.fortran
+!      ^ meta.parens.fortran punctuation.section.parens.begin.fortran
+!       ^^^^^^^^ meta.parens.fortran storage.type.class.fortran
+!               ^ meta.parens.fortran punctuation.section.parens.end.fortran
+!                 ^^ punctuation.separator.double-colon.fortran
+!                    ^^^^^^^^^^ variable.other.fortran
+!
+   type (interval) :: myInterval ! object instance declaration, not type definition
+!  ^^^^ keyword.other.fortran
+!       ^ meta.parens.fortran punctuation.section.parens.begin.fortran
+!        ^^^^^^^^ meta.parens.fortran storage.type.class.fortran
+!                ^ meta.parens.fortran punctuation.section.parens.end.fortran
+!                  ^^ punctuation.separator.double-colon.fortran
+!                     ^^^^^^^^^^ variable.other.fortran
+!
    enddo
 !  ^^^^^ keyword.control.fortran
 !

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -9,6 +9,9 @@
    else if (a == d) then
 !  ^^^^ keyword.control.fortran
 !       ^^ keyword.control.fortran
+!          ^^^^^^^^ meta.parens.fortran
+!          ^ punctuation.section.parens.begin.fortran
+!                 ^ punctuation.section.parens.end.fortran
 !
    else
 !  ^^^^ keyword.control.fortran
@@ -32,6 +35,16 @@
 !
    a = b
 !    ^ keyword.operator.assignment.fortran
+!
+   a = [1, 2, 3]
+!      ^^^^^^^^^ meta.brackets.fortran
+!      ^ punctuation.section.brackets.begin.fortran
+!              ^ punctuation.section.brackets.end.fortran
+!
+   a = (/1, 2, 3/)
+!      ^^^^^^^^^^^ meta.parens.fortran
+!      ^^ punctuation.section.parens.begin.fortran - keyword
+!               ^^ punctuation.section.parens.end.fortran - keyword
 !
    integer(kind=8), dimension(:,:), allocatable :: myInt
 !                                                  ^^^^^ variable.other.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -313,6 +313,9 @@
 !      ^^^ constant.numeric.suffix.fortran
 !   ^ punctuation.separator.decimal.fortran
 !
+   dplusone = d+1
+!              ^ keyword.operator.arithmetic.fortran - constant.numeric
+!
    a = minval(b)
 !      ^^^^^^ support.function.intrinsic.fortran
 !


### PR DESCRIPTION
Pull request for release v1.2.0

### Changelog
- Improvements to module, submodule, and program keywords. Keywords are now highlighted as you type (for incomplete statements), improving the typing experience.
- Isolated `end` is now recognized as a control keyword instead of an `end=` statement in `read`. Improves typing experience when typing code such as `end function`.
- Improvements to recognition of syntax involving numbers
- Missing word boundaries added for some keywords
- Scopes for parentheses and brackets have been added
- Scopes in type instance declaration have been modified (type/class is now `keyword.other` and the class is given by `storage.type.class`)
- Fixed some cases where objects were incorrectly scoped as objects