### PR TITLE
Fix incomplete procedure pointer continuation

### DIFF
--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -452,6 +452,10 @@ contexts:
     - include: separators
     - include: attribute
     - include: pointer-symbol
+    - match: (?=\b(end|procedure|final|generic)\b)
+      pop: true
+      # this pop makes sure we don't recognize the "end type" or the next routine declaration
+      # as a function name when typing "procedure :: myProcedure &"
     - match: \w+
       scope: entity.name.function.fortran
     - match: \n

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -924,4 +924,3 @@ end program myProgram
 !  ^^^ keyword.declaration.class.fortran
 !      ^^^^ keyword.declaration.class.fortran
 !           ^^^^^^^^^^^ entity.name.class.fortran
-!

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -885,3 +885,43 @@ end program myProgram
 !  ^^^^^^ keyword.control.import.fortran
 !         ^^^^^^^^^ variable.other.fortran
 !
+      procedure, private :: myProcedure & 
+
+   end type myProcedure
+!  ^^^ keyword.declaration.class.fortran
+!      ^^^^ keyword.declaration.class.fortran
+!           ^^^^^^^^^^^ entity.name.class.fortran
+!
+      procedure, private :: myProcedure & 
+!     ^^^^^^^^^ keyword.declaration.function.fortran
+!              ^ punctuation.separator.comma.fortran
+!                ^^^^^^^ storage.modifier.fortran
+!                        ^^ punctuation.separator.double-colon.fortran
+!                           ^^^^^^^^^^^ entity.name.function.fortran
+
+      procedure :: otherProcedure
+!               ^^ punctuation.separator.double-colon.fortran
+!     ^^^^^^^^^ keyword.declaration.function.fortran
+!                  ^^^^^^^^^^^^^^ entity.name.function.fortran
+
+   end type myProcedure
+!  ^^^ keyword.declaration.class.fortran
+!      ^^^^ keyword.declaration.class.fortran
+!           ^^^^^^^^^^^ entity.name.class.fortran
+      procedure, private :: myProcedure & 
+!     ^^^^^^^^^ keyword.declaration.function.fortran
+!              ^ punctuation.separator.comma.fortran
+!                ^^^^^^^ storage.modifier.fortran
+!                        ^^ punctuation.separator.double-colon.fortran
+!                           ^^^^^^^^^^^ entity.name.function.fortran
+
+      final :: otherProcedure &
+!     ^^^^^ keyword.declaration.function.fortran
+!           ^^ punctuation.separator.double-colon.fortran
+!              ^^^^^^^^^^^^^^ entity.name.function.fortran
+!
+   end type myProcedure
+!  ^^^ keyword.declaration.class.fortran
+!      ^^^^ keyword.declaration.class.fortran
+!           ^^^^^^^^^^^ entity.name.class.fortran
+!


### PR DESCRIPTION
When writing procedure pointers, we sometimes have incomplete statements like
```fortran

       procedure :: aProcedure &

    end type
```
This adds additional escapes to avoid "end type" being recognized as function names. 