### PR TITLE
Fix errors in syntax tests for Sublime Text 4 and remove incompatibilities with Regex engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: SublimeText/syntax-test-action@v2
         with:
-          build: 'latest'
+          build: 4107
           package_name: ModernFortran

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,17 @@ on:
       - '**.tmPreferences'
 
 jobs:
-  main:
-    name: Run Syntax Tests
+  sublime-text-3:
+    name: Syntax tests (ST3)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: SublimeText/syntax-test-action@v2
+        with:
+          build: 3211
+          package_name: ModernFortran
+  sublime-text-4:
+    name: Syntax tests (ST4)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Modern-Fortran syntax
 
-Modern-Fortran is a [Sublime Text 3](https://www.sublimetext.com/) language syntax for highlighting of Fortran code. It highlights modern Fortran (Fortran 90 and newer) and incorporates features introduced in Fortran 2003, 2008, and 2018. 
+Modern-Fortran is a [Sublime Text](https://www.sublimetext.com/) language syntax for highlighting of Fortran code. It highlights modern Fortran (Fortran 90 and newer) and incorporates features introduced in Fortran 2003, 2008, and 2018. 
 
 ## Installation via Package Control
 The easiest way to get the syntax is to install the package *ModernFortran* with [Package Control](https://packagecontrol.io/). 
@@ -14,7 +14,7 @@ The syntax can also be installed manually.
 Open the terminal and navigate to where packages are installed:
 ```shell
 # Default location on Ubuntu
-cd /home/username/.config/sublime-text-3/Packages 
+cd /home/username/.config/sublime-text/Packages 
 ```
 The location on your computer can be found via `Preferences -> Browse packages...`. Next, clone the repository:
 ```shell

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -208,7 +208,7 @@ contexts:
       scope: keyword.control.fortran
     - match: (?i)\b(exit|cycle|return)\b
       scope: keyword.control.fortran
-    - match: (?i)\b(select)\b\s*\b(case|type|class)\b
+    - match: (?i)\b(select)\b\s*(?:(case|type|class)\b)?
       captures:
         1: keyword.control.fortran
         2: keyword.control.fortran

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -192,9 +192,7 @@ contexts:
       push: seek-conditional-label
     - match: (?i)\b(elseif)\b
       scope: keyword.control.fortran
-    - match: (?i)\b(else|if)\b
-      scope: keyword.control.fortran
-    - match: (?i)\b(if|do|while)\b
+    - match: (?i)\b(else|if|do|while)\b
       scope: keyword.control.fortran
     - match: (?i)(\w+)\s*(\:)\s*(?=do|if|select)
       captures:

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -489,20 +489,27 @@ contexts:
   class-name:
     - meta_scope: meta.class.declaration.fortran
     - include: newline-pop
-    - include: separators
     - include: comment-pop
+    - match: \,
+      scope: punctuation.separator.comma.fortran
+      push: seek-class-modifiers
+    - include: separators
+    - match: (?i)(\w+) # simple type definition (type myType)
+      scope: entity.name.class.fortran
+
+  seek-class-modifiers:
+    - include: eol-pop
     - match: (?i)\b(extends)\b\s*{{parenthesisStart}}\s*(\w*)\s*{{parenthesisEnd}}
       captures:
         1: keyword.control.extends.fortran
         2: entity.other.inherited-class.fortran
-    - match: (?i)\b(abstract)\b
+    - match: (?i)\b(abstract|public|private)\b
       scope: storage.modifier.fortran
-    - match: (?<=::)\s*(\w+)
-      captures:
-        1: entity.name.class.fortran
-    - match: (?i)(?<=type)\s+(\w+) # simple type definition (type myType)
-      captures:
-        1: entity.name.class.fortran
+    - match: (::)
+      scope: punctuation.separator.double-colon.fortran
+      pop: true
+    - include: separators
+
 
   numbers:
     - match: (?i)((?:\b\d+(\.)\d*|(\.)\d+)(?:[de][-+]?\d+)?|\b\d+[de][-+]?\d+)(_\w+)?

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -204,12 +204,14 @@ contexts:
       scope: keyword.control.fortran
     - match: (?i)\b(class)\s+(?=default)\b
       scope: keyword.control.fortran
-    - match: (?i)\b(select|case|default)\b
+    - match: (?i)\b(case|default)\b
       scope: keyword.control.fortran
     - match: (?i)\b(exit|cycle|return)\b
       scope: keyword.control.fortran
-    - match: (?i)(?<=select)\s*(type|class)
-      scope: keyword.control.fortran
+    - match: (?i)\b(select)\b\s*\b(case|type|class)\b
+      captures:
+        1: keyword.control.fortran
+        2: keyword.control.fortran
     - match: (?i)(class\s+is)\b\s*\(\s*(\w+)\s*\)
       captures:
         1: keyword.control.fortran

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -187,10 +187,12 @@ contexts:
     - match: (?i)\b(then|exit|cycle)\b
       scope: keyword.control.fortran
       push: seek-conditional-label
-    - match: (?i)(?<=else)(?!\s*if)
+    - match: (?i)\b(else)\b(?!\s*if)
       scope: keyword.control.fortran
       push: seek-conditional-label
-    - match: (?i)\b(else|elseif)\b
+    - match: (?i)\b(elseif)\b
+      scope: keyword.control.fortran
+    - match: (?i)\b(else|if)\b
       scope: keyword.control.fortran
     - match: (?i)\b(if|do|while)\b
       scope: keyword.control.fortran

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -539,13 +539,12 @@ contexts:
         1: variable.function.fortran
 
   interfaces:
-    - match: (?i)(abstract)\s+(?=interface)
+    - match: (?i)(abstract)\b
       scope: storage.modifier.fortran
-    - match: (?i)\b(interface)\b
-      scope: keyword.declaration.interface.interface.fortran
-    - match: '(?i)(?<=interface)\s+(\w*)'
+    - match: (?i)\b(interface)\b\s*(?:(\w+))?
       captures:
-        1: entity.name.interface.interface.fortran
+        1: keyword.declaration.interface.interface.fortran
+        2: entity.name.interface.interface.fortran
     - match: (?i)\b(include)\b
       scope: keyword.control.import.fortran
     - match: (?i)\b(end)\b\s+(?=interface)

--- a/modern-fortran.sublime-syntax
+++ b/modern-fortran.sublime-syntax
@@ -200,9 +200,6 @@ contexts:
       captures:
         1: entity.name.label.conditional.fortran
         2: punctuation.separator.single-colon.fortran
-    # do concurrent
-    - match: (?i)(?<=do)\s+(concurrent)\b
-      scope: keyword.control.fortran
     - match: (?i)\b(concurrent|local|shared|local_init|default)\b
       scope: keyword.control.fortran
     - match: (?i)\b(class)\s+(?=default)\b

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -500,11 +500,13 @@
 !                         ^^^ variable.other.fortran
 !
 #ifdef myVar
-!<-^^^ keyword.control.directive.fortran
+!<- keyword.control.directive.fortran
+!^^^^^ keyword.control.directive.fortran
 !      ^^^^^ variable.other.fortran
    integer, parameter :: p = 1
 #else
-!<-^^ keyword.control.directive.fortran
+!<- keyword.control.directive.fortran
+!^^^^ keyword.control.directive.fortran
    integer, parameter :: p = 2
 #endif
 !<- keyword.control.directive.fortran
@@ -516,7 +518,8 @@
 !                     ^ punctuation.definition.string.end.fortran
 
 !$omp parallel do private(I) schedule(dynamic)
-!<^^^ keyword.control.directive.fortran
+! <- keyword.control.directive.fortran
+!^^^^ keyword.control.directive.fortran
 !                            ^^^^^^^^ keyword.control.directive.fortran
 !     ^^^^^^^^ keyword.control.directive.fortran
 !              ^^ keyword.control.directive.fortran
@@ -534,7 +537,8 @@
 !
    enddo
 !$omp end parallel do
-!<^^^ keyword.control.directive.fortran
+!<- keyword.control.directive.fortran
+!^^^^ keyword.control.directive.fortran
 !                  ^^ keyword.control.directive.fortran
 !     ^^^ keyword.control.directive.fortran
 !         ^^^^^^^^ keyword.control.directive.fortran
@@ -557,9 +561,9 @@
 !                    ^^^^^^^^^^ entity.name.function.fortran
 !
 program myProgram
-!<-^^^^ keyword.declaration.program.fortran
+!<- meta.program.declaration.fortran keyword.declaration.program.fortran
+!^^^^^^ meta.program.declaration.fortran keyword.declaration.program.fortran
 !       ^^^^^^^^^ entity.name.program.fortran
-!<-^^^^^^^^^^^^^^ meta.program.declaration.fortran
 !
 !  Program contents
 !

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -628,7 +628,8 @@ end program myProgram
 !             ^^^^^^^^^^^ entity.name.label.conditional.fortran
 !
    select type (animal)
-!  ^^^^^^^^^^^ keyword.control.fortran
+!  ^^^^^^ keyword.control.fortran
+!         ^^^^ keyword.control.fortran
 !               ^^^^^^ variable.other.fortran
 !
       type is (cat)
@@ -643,8 +644,12 @@ end program myProgram
 !
    animalCasting: select class (animal)
 !  ^^^^^^^^^^^^^ entity.name.label.conditional.fortran
-!                 ^^^^^^^^^^^^ keyword.control.fortran
+!               ^ punctuation.separator.single-colon.fortran
+!                 ^^^^^^ keyword.control.fortran
+!                        ^^^^^ keyword.control.fortran
+!                              ^ meta.parens.fortran punctuation.section.parens.begin.fortran
 !                               ^^^^^^ variable.other.fortran
+!                                     ^ meta.parens.fortran punctuation.section.parens.end.fortran
 !
       class is (cat)
 !     ^^^^^^^^ keyword.control.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -602,6 +602,14 @@ end program myProgram
    DEALLOCATE(array)
 !  ^^^^^^^^^^ support.function.subroutine.fortran
 !
+   select
+!  ^^^^^^ keyword.control.fortran
+!
+   select classoij 
+!  ^^^^^^ keyword.control.fortran
+!         ^^^^^ - keyword.control.fortran
+!              (should not recognize "class" in "classoij")
+!
    select case (myString)
 !  ^^^^^^ keyword.control.fortran
 !         ^^^^ keyword.control.fortran

--- a/syntax_test_fortran.F90
+++ b/syntax_test_fortran.F90
@@ -579,6 +579,8 @@ end program myProgram
    ENDDO
 !  ^^^^^ keyword.control.fortran
 !
+   type, 
+!
    TYPE simpleStruct
 !  ^^^^ keyword.declaration.class.fortran
 !       ^^^^^^^^^^^^ entity.name.class.fortran
@@ -674,6 +676,14 @@ end program myProgram
 !                  ^^^^^^^ keyword.control.extends.fortran
 !                ^ punctuation.separator.comma.fortran
 !                               ^^ punctuation.separator.double-colon.fortran
+!
+   type, private, extends(cat) :: superCat
+!  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.class.declaration.fortran 
+!      ^ punctuation.separator.comma.fortran
+!        ^^^^^^^ storage.modifier.fortran
+!                 ^^^^^^^ keyword.control.extends.fortran
+!               ^ punctuation.separator.comma.fortran
+!                              ^^ punctuation.separator.double-colon.fortran
 !
    MODULE SUBROUTINE MY_SUBROUTINE(A, B, C)
 !  ^^^^^^ storage.modifier.function.prefix.fortran


### PR DESCRIPTION
- Minor improvement when typing select constructs 
- Add accessibility modifiers to type declarations (`type, private :: myType`)
- Remove all look-behinds for compatibility with newest Regex engine
- Fixes errors in Sublime Text 4 syntax tests (these were apparently caused by a change in how the test comments are read, especially the syntax for `<-`)
- Add Syntax Test pipeline for both ST3 and ST4 to make sure syntax is compatible with both versions of Sublime Text